### PR TITLE
chore: update repo references from UXFoundry to shauntrennery

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "keywords": ["hashdo", "cards"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/UXFoundry/hashdo.git"
+    "url": "https://github.com/shauntrennery/hashdo.git"
   },
   "bugs": {
-    "url": "https://github.com/UXFoundry/hashdo/issues"
+    "url": "https://github.com/shauntrennery/hashdo/issues"
   },
   "dependencies": {
     "async": "2.5.0",

--- a/v2/demo-cards/book/card.ts
+++ b/v2/demo-cards/book/card.ts
@@ -304,7 +304,7 @@ async function searchBook(query: string): Promise<BookResult | null> {
 
     const url = `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=1&fields=${fields}`;
     const res = await fetch(url, {
-      headers: { 'User-Agent': 'HashDo/2.0 (https://github.com/UXFoundry/hashdo)' },
+      headers: { 'User-Agent': 'HashDo/2.0 (https://github.com/shauntrennery/hashdo)' },
     });
 
     if (!res.ok) {

--- a/v2/demo-cards/github-repo/card.ts
+++ b/v2/demo-cards/github-repo/card.ts
@@ -22,7 +22,7 @@ export default defineCard({
   },
 
   async getData({ inputs, state }) {
-    const raw = ((inputs.repo as string) ?? 'UXFoundry/hashdo').trim();
+    const raw = ((inputs.repo as string) ?? 'shauntrennery/hashdo').trim();
     if (!raw) {
       throw new Error('Please provide a repository in "owner/name" format.');
     }
@@ -298,7 +298,7 @@ async function searchRepo(query: string): Promise<{ owner: string; name: string 
       {
         headers: {
           'Accept': 'application/vnd.github+json',
-          'User-Agent': 'HashDo/2.0 (https://github.com/UXFoundry/hashdo)',
+          'User-Agent': 'HashDo/2.0 (https://github.com/shauntrennery/hashdo)',
         },
       }
     );
@@ -320,7 +320,7 @@ async function fetchRepo(owner: string, name: string): Promise<RepoData | null> 
       {
         headers: {
           'Accept': 'application/vnd.github+json',
-          'User-Agent': 'HashDo/2.0 (https://github.com/UXFoundry/hashdo)',
+          'User-Agent': 'HashDo/2.0 (https://github.com/shauntrennery/hashdo)',
         },
       }
     );

--- a/v2/packages/cli/src/cli.ts
+++ b/v2/packages/cli/src/cli.ts
@@ -793,7 +793,7 @@ function renderIndex(cards: CardDefinition[]): string {
   <nav class="top-nav">
     <a href="/docs" class="nav-link">Developer Docs</a>
     <a href="/editor" class="nav-link">Card Editor</a>
-    <a href="https://github.com/UXFoundry/hashdo" class="nav-link">GitHub</a>
+    <a href="https://github.com/shauntrennery/hashdo" class="nav-link">GitHub</a>
   </nav>
   <main>
     <section class="hero">
@@ -826,7 +826,7 @@ function renderIndex(cards: CardDefinition[]): string {
     <p class="no-results" id="noResults">No cards match your search.</p>
 
     <footer>
-      <a href="/docs">Docs</a><span class="dot">\u00B7</span><a href="/editor">Editor</a><span class="dot">\u00B7</span><a href="/privacy">Privacy</a><span class="dot">\u00B7</span><a href="/terms">Terms</a><span class="dot">\u00B7</span><a href="https://github.com/UXFoundry/hashdo">GitHub</a>
+      <a href="/docs">Docs</a><span class="dot">\u00B7</span><a href="/editor">Editor</a><span class="dot">\u00B7</span><a href="/privacy">Privacy</a><span class="dot">\u00B7</span><a href="/terms">Terms</a><span class="dot">\u00B7</span><a href="https://github.com/shauntrennery/hashdo">GitHub</a>
     </footer>
   </main>
   <script>
@@ -1049,7 +1049,7 @@ export default defineCard({
 
 <h2>Submitting Cards</h2>
 <ol>
-  <li><strong>Fork</strong> the <a href="https://github.com/UXFoundry/hashdo">HashDo repository</a> on GitHub</li>
+  <li><strong>Fork</strong> the <a href="https://github.com/shauntrennery/hashdo">HashDo repository</a> on GitHub</li>
   <li><strong>Create</strong> your card directory under <code>v2/demo-cards/</code></li>
   <li><strong>Test</strong> locally with <code>hashdo preview</code></li>
   <li><strong>Submit</strong> a pull request with your card</li>
@@ -1687,7 +1687,7 @@ const PRIVACY_POLICY = `
 <p>We may update this policy from time to time. Changes will be reflected on this page with an updated date.</p>
 
 <h2>Contact</h2>
-<p>Questions? Reach us at <a href="https://github.com/UXFoundry/hashdo">github.com/UXFoundry/hashdo</a>.</p>
+<p>Questions? Reach us at <a href="https://github.com/shauntrennery/hashdo">github.com/shauntrennery/hashdo</a>.</p>
 `;
 
 const TERMS_OF_SERVICE = `
@@ -1727,7 +1727,7 @@ const TERMS_OF_SERVICE = `
 <p>We may update these terms at any time. Continued use of the Service after changes constitutes acceptance of the updated terms.</p>
 
 <h2>Contact</h2>
-<p>Questions? Reach us at <a href="https://github.com/UXFoundry/hashdo">github.com/UXFoundry/hashdo</a>.</p>
+<p>Questions? Reach us at <a href="https://github.com/shauntrennery/hashdo">github.com/shauntrennery/hashdo</a>.</p>
 `;
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Updated all `UXFoundry/hashdo` references to `shauntrennery/hashdo` after repo transfer
- Updated git remote URL
- Also includes fix for inline script execution in MCP Apps widgets and poll card compatibility

**Files changed:**
- `package.json` — repository + bugs URLs
- `v2/demo-cards/book/card.ts` — User-Agent header
- `v2/demo-cards/github-repo/card.ts` — default repo input + User-Agent headers
- `v2/packages/cli/src/cli.ts` — navbar, footer, docs, privacy/terms links
- `v2/packages/mcp-adapter/src/server.ts` — widget script re-creation fix
- `v2/demo-cards/poll/card.ts` — document.currentScript fix

## Test plan
- [ ] Verify no remaining `UXFoundry` references in codebase
- [ ] Confirm GitHub repo card defaults to `shauntrennery/hashdo`
- [ ] Confirm games and poll card work in ChatGPT MCP Apps widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)