### PR TITLE
feat(v2): add Upstash Redis state persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "keywords": ["hashdo", "cards"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/UXFoundry/hashdo.git"
+    "url": "https://github.com/shauntrennery/hashdo.git"
   },
   "bugs": {
-    "url": "https://github.com/UXFoundry/hashdo/issues"
+    "url": "https://github.com/shauntrennery/hashdo/issues"
   },
   "dependencies": {
     "async": "2.5.0",

--- a/v2/.env.example
+++ b/v2/.env.example
@@ -1,0 +1,7 @@
+# Upstash Redis — state persistence for cards (poll votes, vocab lists, etc.)
+# Get credentials from https://console.upstash.com
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# Optional: state TTL in seconds (default: 2592000 = 30 days)
+# HASHDO_STATE_TTL_SECONDS=2592000

--- a/v2/demo-cards/book/card.ts
+++ b/v2/demo-cards/book/card.ts
@@ -304,7 +304,7 @@ async function searchBook(query: string): Promise<BookResult | null> {
 
     const url = `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=1&fields=${fields}`;
     const res = await fetch(url, {
-      headers: { 'User-Agent': 'HashDo/2.0 (https://github.com/UXFoundry/hashdo)' },
+      headers: { 'User-Agent': 'HashDo/2.0 (https://github.com/shauntrennery/hashdo)' },
     });
 
     if (!res.ok) {

--- a/v2/demo-cards/github-repo/card.ts
+++ b/v2/demo-cards/github-repo/card.ts
@@ -22,7 +22,7 @@ export default defineCard({
   },
 
   async getData({ inputs, state }) {
-    const raw = ((inputs.repo as string) ?? 'UXFoundry/hashdo').trim();
+    const raw = ((inputs.repo as string) ?? 'shauntrennery/hashdo').trim();
     if (!raw) {
       throw new Error('Please provide a repository in "owner/name" format.');
     }
@@ -298,7 +298,7 @@ async function searchRepo(query: string): Promise<{ owner: string; name: string 
       {
         headers: {
           'Accept': 'application/vnd.github+json',
-          'User-Agent': 'HashDo/2.0 (https://github.com/UXFoundry/hashdo)',
+          'User-Agent': 'HashDo/2.0 (https://github.com/shauntrennery/hashdo)',
         },
       }
     );
@@ -320,7 +320,7 @@ async function fetchRepo(owner: string, name: string): Promise<RepoData | null> 
       {
         headers: {
           'Accept': 'application/vnd.github+json',
-          'User-Agent': 'HashDo/2.0 (https://github.com/UXFoundry/hashdo)',
+          'User-Agent': 'HashDo/2.0 (https://github.com/shauntrennery/hashdo)',
         },
       }
     );

--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -546,6 +546,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.2.tgz",
+      "integrity": "sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1001,6 +1010,18 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2342,6 +2363,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -2509,7 +2536,9 @@
       "dependencies": {
         "@hashdo/core": "2.0.0-alpha.1",
         "@hashdo/mcp-adapter": "2.0.0-alpha.1",
-        "@hashdo/screenshot": "2.0.0-alpha.1"
+        "@hashdo/screenshot": "2.0.0-alpha.1",
+        "@upstash/redis": "^1.34.3",
+        "dotenv": "^16.4.7"
       },
       "bin": {
         "hashdo": "dist/cli.js"

--- a/v2/packages/cli/package.json
+++ b/v2/packages/cli/package.json
@@ -14,7 +14,9 @@
   "dependencies": {
     "@hashdo/core": "2.0.0-alpha.1",
     "@hashdo/mcp-adapter": "2.0.0-alpha.1",
-    "@hashdo/screenshot": "2.0.0-alpha.1"
+    "@hashdo/screenshot": "2.0.0-alpha.1",
+    "@upstash/redis": "1.34.3",
+    "dotenv": "16.4.7"
   },
   "devDependencies": {
     "@types/node": "25.2.2",

--- a/v2/packages/cli/src/cli.ts
+++ b/v2/packages/cli/src/cli.ts
@@ -793,7 +793,7 @@ function renderIndex(cards: CardDefinition[]): string {
   <nav class="top-nav">
     <a href="/docs" class="nav-link">Developer Docs</a>
     <a href="/editor" class="nav-link">Card Editor</a>
-    <a href="https://github.com/UXFoundry/hashdo" class="nav-link">GitHub</a>
+    <a href="https://github.com/shauntrennery/hashdo" class="nav-link">GitHub</a>
   </nav>
   <main>
     <section class="hero">
@@ -826,7 +826,7 @@ function renderIndex(cards: CardDefinition[]): string {
     <p class="no-results" id="noResults">No cards match your search.</p>
 
     <footer>
-      <a href="/docs">Docs</a><span class="dot">\u00B7</span><a href="/editor">Editor</a><span class="dot">\u00B7</span><a href="/privacy">Privacy</a><span class="dot">\u00B7</span><a href="/terms">Terms</a><span class="dot">\u00B7</span><a href="https://github.com/UXFoundry/hashdo">GitHub</a>
+      <a href="/docs">Docs</a><span class="dot">\u00B7</span><a href="/editor">Editor</a><span class="dot">\u00B7</span><a href="/privacy">Privacy</a><span class="dot">\u00B7</span><a href="/terms">Terms</a><span class="dot">\u00B7</span><a href="https://github.com/shauntrennery/hashdo">GitHub</a>
     </footer>
   </main>
   <script>
@@ -1049,7 +1049,7 @@ export default defineCard({
 
 <h2>Submitting Cards</h2>
 <ol>
-  <li><strong>Fork</strong> the <a href="https://github.com/UXFoundry/hashdo">HashDo repository</a> on GitHub</li>
+  <li><strong>Fork</strong> the <a href="https://github.com/shauntrennery/hashdo">HashDo repository</a> on GitHub</li>
   <li><strong>Create</strong> your card directory under <code>v2/demo-cards/</code></li>
   <li><strong>Test</strong> locally with <code>hashdo preview</code></li>
   <li><strong>Submit</strong> a pull request with your card</li>
@@ -1687,7 +1687,7 @@ const PRIVACY_POLICY = `
 <p>We may update this policy from time to time. Changes will be reflected on this page with an updated date.</p>
 
 <h2>Contact</h2>
-<p>Questions? Reach us at <a href="https://github.com/UXFoundry/hashdo">github.com/UXFoundry/hashdo</a>.</p>
+<p>Questions? Reach us at <a href="https://github.com/shauntrennery/hashdo">github.com/shauntrennery/hashdo</a>.</p>
 `;
 
 const TERMS_OF_SERVICE = `
@@ -1727,7 +1727,7 @@ const TERMS_OF_SERVICE = `
 <p>We may update these terms at any time. Continued use of the Service after changes constitutes acceptance of the updated terms.</p>
 
 <h2>Contact</h2>
-<p>Questions? Reach us at <a href="https://github.com/UXFoundry/hashdo">github.com/UXFoundry/hashdo</a>.</p>
+<p>Questions? Reach us at <a href="https://github.com/shauntrennery/hashdo">github.com/shauntrennery/hashdo</a>.</p>
 `;
 
 main().catch((err) => {

--- a/v2/packages/cli/src/create-state-store.ts
+++ b/v2/packages/cli/src/create-state-store.ts
@@ -1,0 +1,25 @@
+import { MemoryStateStore, type StateStore } from '@hashdo/core';
+import { UpstashStateStore } from './upstash-state-store.js';
+
+/**
+ * Create the appropriate StateStore based on environment variables.
+ * Falls back to MemoryStateStore when Upstash credentials aren't configured.
+ */
+export function createStateStore(): StateStore {
+  const url = process.env['UPSTASH_REDIS_REST_URL'];
+  const token = process.env['UPSTASH_REDIS_REST_TOKEN'];
+
+  if (url && token) {
+    const ttlSeconds = process.env['HASHDO_STATE_TTL_SECONDS']
+      ? parseInt(process.env['HASHDO_STATE_TTL_SECONDS'], 10)
+      : undefined;
+
+    console.error('[hashdo] Using Upstash Redis for state persistence');
+    return new UpstashStateStore({ url, token, ttlSeconds });
+  }
+
+  console.error(
+    '[hashdo] No UPSTASH_REDIS_REST_URL configured — using in-memory state (state will not persist across requests)'
+  );
+  return new MemoryStateStore();
+}

--- a/v2/packages/cli/src/upstash-state-store.ts
+++ b/v2/packages/cli/src/upstash-state-store.ts
@@ -1,0 +1,36 @@
+import { Redis } from '@upstash/redis';
+import type { CardState, StateStore } from '@hashdo/core';
+
+export interface UpstashStateStoreOptions {
+  url: string;
+  token: string;
+  /** TTL in seconds for state entries. Default: 2_592_000 (30 days). */
+  ttlSeconds?: number;
+}
+
+/**
+ * Persistent state store backed by Upstash Redis (REST API).
+ * Works in stateless/serverless contexts — no persistent TCP connections.
+ */
+export class UpstashStateStore implements StateStore {
+  private redis: Redis;
+  private ttlSeconds: number;
+
+  constructor(options: UpstashStateStoreOptions) {
+    this.redis = new Redis({ url: options.url, token: options.token });
+    this.ttlSeconds = options.ttlSeconds ?? 2_592_000; // 30 days
+  }
+
+  async get(cardKey: string): Promise<CardState | null> {
+    const data = await this.redis.get<CardState>(cardKey);
+    return data ?? null;
+  }
+
+  async set(cardKey: string, state: CardState): Promise<void> {
+    await this.redis.set(cardKey, state, { ex: this.ttlSeconds });
+  }
+
+  async delete(cardKey: string): Promise<void> {
+    await this.redis.del(cardKey);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `UpstashStateStore` implementing the existing `StateStore` interface via `@upstash/redis` REST client
- Cards like poll, define, and usage counters now persist state across requests and server restarts
- Falls back to `MemoryStateStore` when `UPSTASH_REDIS_REST_URL` is not configured (no breaking change)
- State entries have a 30-day TTL (configurable via `HASHDO_STATE_TTL_SECONDS`)

## Test plan
- [ ] Run `hashdo start ./demo-cards` without env vars — should log "using in-memory state" and work as before
- [ ] Set `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in `.env`, run `hashdo start` — should log "Using Upstash Redis"
- [ ] Use `do-poll` via MCP, vote, restart server, re-render — votes should persist
- [ ] Verify `.env` is not committed (gitignored), `.env.example` is committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)