### PR TITLE
feat(v2): poll IDs and custom state key support

### DIFF
--- a/v2/packages/core/src/types.ts
+++ b/v2/packages/core/src/types.ts
@@ -143,6 +143,13 @@ export interface CardDefinition<S extends InputSchema = InputSchema> {
   onWebhook?: (context: WebhookContext) => Promise<WebhookResult>;
 
   /**
+   * Custom state key derived from inputs. When defined, the MCP adapter uses
+   * this instead of hashing all inputs. Return undefined to fall back to the
+   * default behaviour (hash of all inputs).
+   */
+  stateKey?: (inputs: InputValues<S>) => string | undefined;
+
+  /**
    * Template for rendering the card UI.
    * - String ending in .hbs/.html → file path relative to card directory
    * - Function → receives viewModel, returns HTML string

--- a/v2/packages/mcp-adapter/src/server.ts
+++ b/v2/packages/mcp-adapter/src/server.ts
@@ -249,7 +249,10 @@ function registerCardTool(
     },
     async (params: Record<string, unknown>) => {
       const inputs = params as any;
-      const cardKey = `card:${card.name}:${stableKey(inputs)}`;
+      const customKey = card.stateKey?.(inputs);
+      const cardKey = customKey
+        ? `card:${card.name}:${customKey}`
+        : `card:${card.name}:${stableKey(inputs)}`;
 
       // Load existing state
       const state = (await stateStore.get(cardKey)) ?? {};
@@ -353,7 +356,10 @@ function registerActionTools(
           }
         }
 
-        const cardKey = `card:${card.name}:${stableKey(cardInputs)}`;
+        const customKey = card.stateKey?.(cardInputs as any);
+        const cardKey = customKey
+          ? `card:${card.name}:${customKey}`
+          : `card:${card.name}:${stableKey(cardInputs)}`;
         const state = (await stateStore.get(cardKey)) ?? {};
 
         const result = await action.handler({


### PR DESCRIPTION
## Summary
- Adds `stateKey` hook to `CardDefinition` — lets cards control their own state key instead of the default hash-of-all-inputs
- MCP adapter uses `card.stateKey()` in both card tools and action tools when defined
- Poll card now has an `id` input — omit to create (ID auto-derived from question+options), provide to reopen an existing poll
- Question, options, and votes are stored in state and restored when opening by ID
- Poll ID displayed in card header and text output

## Test plan
- [ ] Create poll: `do-poll(question="Fav lang?", options="TS, Python, Rust")` — returns poll with ID (e.g. `a3f2b1`)
- [ ] Reopen poll: `do-poll(id="a3f2b1")` — shows same question, options, and votes
- [ ] Vote via action: `do-poll__vote(id="a3f2b1", choice="TS")` — vote persists
- [ ] Same question+options always produces the same poll ID (idempotent)
- [ ] Cards without `stateKey` are unaffected (existing behaviour preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)