### PR TITLE
fix(v2): improve AI parameter mapping for #do/poll <id>

### DIFF
--- a/v2/demo-cards/poll/card.ts
+++ b/v2/demo-cards/poll/card.ts
@@ -12,14 +12,14 @@ function derivePollId(question: string, options: string): string {
 export default defineCard({
   name: 'do-poll',
   description:
-    'Create an interactive poll or survey. Provide question + options to create a new poll (returns an id). Provide just an id to open an existing poll.',
+    'Create or open an interactive poll. Usage: "#do/poll" with question + options creates a new poll. "#do/poll <id>" (e.g. "#do/poll 71a1bc") opens an existing poll by its 6-character hex ID — pass the ID as the "id" parameter, do NOT pass question or options when opening by ID.',
 
   inputs: {
     id: {
       type: 'string',
       required: false,
       description:
-        'Poll ID. Omit when creating a new poll (one will be generated). Provide to open an existing poll.',
+        'Poll ID (6-character hex string). When the user types "#do/poll 71a1bc", map "71a1bc" to this parameter. Omit only when creating a brand-new poll.',
     },
     question: {
       type: 'string',

--- a/v2/packages/mcp-adapter/src/server.ts
+++ b/v2/packages/mcp-adapter/src/server.ts
@@ -206,10 +206,11 @@ ${cardList}
 
 Behavior:
 - When the user types "#do/weather" or "#do/weather Tokyo", call the do-weather tool right away.
-- Parse any text after the command as input (e.g. "#do/weather Paris" → city: "Paris").
+- Parse any text after the command as the most likely input parameter (e.g. "#do/weather Paris" → city: "Paris", "#do/poll a1b2c3" → id: "a1b2c3").
+- When a single unlabeled argument follows a command, map it to the parameter that best matches (check descriptions). For cards with an "id" parameter, a short hex string is almost certainly the id.
 - If the tool returns text output, present it directly to the user formatted nicely.
 - You can also invoke these tools proactively when relevant to the conversation.
-- All inputs are optional unless marked required — the cards have smart defaults.
+- All inputs are optional unless marked required — the cards have smart defaults. Do NOT pass default values yourself — let the card handle defaults.
 - When the user types just "#do" or "#do/list", call the "do-list" tool to show available commands.`;
 }
 


### PR DESCRIPTION
## Summary
- Updated poll card description and `id` input description to explicitly tell the AI that `#do/poll 71a1bc` means pass `71a1bc` as the `id` parameter
- Updated MCP `generateInstructions` to teach AIs how to map unlabeled arguments (especially hex strings) to named parameters like `id`
- Added guidance to not pass default values — let cards handle their own defaults

## Test plan
- [ ] Connect to MCP server, type `#do/poll 71a1bc` — AI should call `do-poll` with `id: "71a1bc"` instead of asking for question/options

🤖 Generated with [Claude Code](https://claude.com/claude-code)