### PR TITLE
fix(v2): add missing demo cards to Dockerfile

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -16,11 +16,17 @@ COPY packages/core/package.json packages/core/
 COPY packages/screenshot/package.json packages/screenshot/
 COPY packages/mcp-adapter/package.json packages/mcp-adapter/
 COPY packages/cli/package.json packages/cli/
+COPY demo-cards/book/package.json demo-cards/book/
+COPY demo-cards/city-explorer/package.json demo-cards/city-explorer/
+COPY demo-cards/crypto-quote/package.json demo-cards/crypto-quote/
+COPY demo-cards/define/package.json demo-cards/define/
+COPY demo-cards/game/snake/package.json demo-cards/game/snake/
+COPY demo-cards/game/wordle/package.json demo-cards/game/wordle/
+COPY demo-cards/github-repo/package.json demo-cards/github-repo/
+COPY demo-cards/poll/package.json demo-cards/poll/
 COPY demo-cards/qr-code/package.json demo-cards/qr-code/
 COPY demo-cards/stock-quote/package.json demo-cards/stock-quote/
 COPY demo-cards/weather/package.json demo-cards/weather/
-COPY demo-cards/crypto-quote/package.json demo-cards/crypto-quote/
-COPY demo-cards/city-explorer/package.json demo-cards/city-explorer/
 RUN npm install
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- Added missing `package.json` COPY lines for `book`, `define`, `game/snake`, `game/wordle`, `github-repo`, and `poll` demo cards
- Ensures `npm install` picks up all workspace dependencies during Docker builds

## Test plan
- [ ] Railway deployment builds successfully
- [ ] All demo cards appear on hashdo.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)