### PR TITLE
fix: pipe baseUrl to cards via renderCard context

### DIFF
--- a/v2/demo-cards/poll/card.ts
+++ b/v2/demo-cards/poll/card.ts
@@ -51,7 +51,7 @@ export default defineCard({
     return undefined;
   },
 
-  async getData({ inputs, state }) {
+  async getData({ inputs, state, baseUrl }) {
     const inputId = inputs.id as string | undefined;
     const inputQuestion = inputs.question as string | undefined;
     const inputOptions = inputs.options as string | undefined;
@@ -147,7 +147,7 @@ export default defineCard({
         voterCount,
         closed,
         allowMultiple: inputs.allowMultiple ?? false,
-        apiBaseUrl: process.env['BASE_URL'] ?? '',
+        apiBaseUrl: baseUrl,
       },
       textOutput,
       state: {

--- a/v2/packages/cli/src/cli.ts
+++ b/v2/packages/cli/src/cli.ts
@@ -336,6 +336,7 @@ async function renderCardWithState(
   inputs: Record<string, unknown>,
   store: StateStore,
   cardDir?: string,
+  baseUrl?: string,
 ) {
   const customKey = card.stateKey?.(inputs as any);
   const cardKey = customKey
@@ -343,7 +344,7 @@ async function renderCardWithState(
     : `card:${card.name}:${stableKey(inputs)}`;
 
   const state = (await store.get(cardKey)) ?? {};
-  const result = await renderCard(card, inputs as any, state, cardDir);
+  const result = await renderCard(card, inputs as any, state, cardDir, { baseUrl });
 
   if (result.state && Object.keys(result.state).length > 0) {
     await store.set(cardKey, result.state);
@@ -485,7 +486,7 @@ async function cmdStart() {
       try {
         trackCardUsage(entry.card.name);
         const inputs = parseInputsFromParams(url.searchParams);
-        const result = await renderCardWithState(entry.card, inputs, stateStore, entry.dir);
+        const result = await renderCardWithState(entry.card, inputs, stateStore, entry.dir, mcpOptions.baseUrl);
         const imageBuffer = await renderHtmlToImage(result.html);
         if (!imageBuffer) {
           res.writeHead(503, { ...corsHeaders, 'Content-Type': 'application/json' });
@@ -605,7 +606,7 @@ async function cmdStart() {
       }
       try {
         trackCardUsage(entry.card.name);
-        const result = await renderCardWithState(entry.card, inputs, stateStore, entry.dir);
+        const result = await renderCardWithState(entry.card, inputs, stateStore, entry.dir, mcpOptions.baseUrl);
         const baseUrl = process.env['BASE_URL'] ?? `http://localhost:${port}`;
         const imageParams = new URLSearchParams();
         for (const [key, value] of Object.entries(inputs)) {
@@ -705,7 +706,7 @@ async function cmdStart() {
 
       try {
         trackCardUsage(entry.card.name);
-        const result = await renderCardWithState(entry.card, inputs, stateStore, entry.dir);
+        const result = await renderCardWithState(entry.card, inputs, stateStore, entry.dir, mcpOptions.baseUrl);
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(renderPreviewPage(entry.card, result.html, inputs));
       } catch (err: any) {

--- a/v2/packages/core/src/render.ts
+++ b/v2/packages/core/src/render.ts
@@ -16,7 +16,9 @@ export async function renderCard<S extends InputSchema>(
   inputs: InputValues<S>,
   state: CardState,
   /** Absolute path to the directory containing the card (for resolving template files) */
-  cardDir?: string
+  cardDir?: string,
+  /** Runtime options forwarded to getData */
+  options?: { baseUrl?: string }
 ): Promise<{ html: string; state: CardState; textOutput?: string; viewModel: Record<string, unknown> }> {
   // 0. Apply defaults for any missing inputs
   const resolvedInputs = { ...inputs };
@@ -27,7 +29,7 @@ export async function renderCard<S extends InputSchema>(
   }
 
   // 1. Fetch data
-  const result = await card.getData({ inputs: resolvedInputs, state });
+  const result = await card.getData({ inputs: resolvedInputs, state, baseUrl: options?.baseUrl ?? '' });
   const newState = { ...state, ...result.state };
 
   // 2. Resolve template

--- a/v2/packages/core/src/types.ts
+++ b/v2/packages/core/src/types.ts
@@ -87,6 +87,8 @@ export interface GetDataContext<S extends InputSchema = InputSchema> {
   inputs: InputValues<S>;
   /** Previously persisted card state (empty object on first render) */
   state: CardState;
+  /** Base URL of the card server (e.g. "https://app.up.railway.app"). Empty string when unknown. */
+  baseUrl: string;
 }
 
 export interface GetDataResult {

--- a/v2/packages/mcp-adapter/src/server.ts
+++ b/v2/packages/mcp-adapter/src/server.ts
@@ -192,7 +192,7 @@ export function createMcpCardServer(options: McpCardServerOptions) {
   );
 
   for (const card of cards) {
-    registerCardTool(server, card, stateStore, cardDirs[card.name], enableScreenshots, connectDomains);
+    registerCardTool(server, card, stateStore, cardDirs[card.name], enableScreenshots, connectDomains, options.baseUrl);
     registerActionTools(server, card, stateStore);
   }
 
@@ -236,7 +236,8 @@ function registerCardTool(
   stateStore: StateStore,
   cardDir: string | undefined,
   enableScreenshots: boolean,
-  connectDomains: string[]
+  connectDomains: string[],
+  baseUrl?: string
 ) {
   const zodShape = inputSchemaToZodShape(card.inputs);
 
@@ -273,7 +274,7 @@ function registerCardTool(
       const state = (await stateStore.get(cardKey)) ?? {};
 
       // Render card
-      const result = await renderCard(card, inputs, state, cardDir);
+      const result = await renderCard(card, inputs, state, cardDir, { baseUrl });
 
       // Persist updated state
       if (result.state && Object.keys(result.state).length > 0) {


### PR DESCRIPTION
## Summary
- Widget vote fetch was hitting Azure Blob Storage (iframe host) with 405 because poll card used `process.env['BASE_URL']` which isn't set in all contexts
- Added `baseUrl` to `GetDataContext` in `@hashdo/core` so cards get the server URL reliably
- `renderCard()` now accepts optional `{ baseUrl }` options, piped from MCP adapter and CLI
- Poll card reads `baseUrl` from context instead of env var

## Changes
- `@hashdo/core` types.ts — added `baseUrl: string` to `GetDataContext`
- `@hashdo/core` render.ts — new optional 5th param `options?: { baseUrl?: string }`
- `@hashdo/mcp-adapter` server.ts — passes `baseUrl` through `registerCardTool` to `renderCard`
- `@hashdo/cli` cli.ts — passes `mcpOptions.baseUrl` through `renderCardWithState` to `renderCard`
- `demo-cards/poll/card.ts` — uses `baseUrl` from getData context instead of `process.env`

## Test plan
- [ ] Deploy to Railway — vote fetch should go to Railway URL, not iframe host
- [ ] Click poll option in MCP Apps widget — vote persists (no 405)
- [ ] Local dev (`hashdo start`) — falls back to `http://localhost:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)