### PR TITLE
feat(core): handle defaults and error rendering in defineCard

### DIFF
--- a/v2/demo-cards/book/card.ts
+++ b/v2/demo-cards/book/card.ts
@@ -10,14 +10,15 @@ import { defineCard } from '@hashdo/core';
 export default defineCard({
   name: 'do-book',
   description:
-    'Look up any book by title, author, or ISBN. Shows cover, author, publication info, and subjects. Call this when the user types #do/book or asks about a book.',
+    'Look up any book by title, author, or ISBN. Shows cover, author, publication info, and subjects. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a book, pass it; otherwise use defaults.',
 
   inputs: {
     query: {
       type: 'string',
-      required: true,
+      required: false,
+      default: 'The Great Gatsby',
       description:
-        'Book title, author name, or ISBN to search for (e.g. "The Great Gatsby", "Tolkien", "978-0451524935")',
+        'Book title, author name, or ISBN to search for. Has a sensible default — only override if the user specifies a book.',
     },
   },
 

--- a/v2/demo-cards/city-explorer/card.ts
+++ b/v2/demo-cards/city-explorer/card.ts
@@ -12,14 +12,15 @@ import { defineCard } from '@hashdo/core';
 export default defineCard({
   name: 'do-city',
   description:
-    'Explore any city in the world. Shows current weather, local time, country flag, population, currency, and languages in a single card. Call this when the user types #do/city or asks about a city.',
+    'Explore any city in the world. Shows current weather, local time, country flag, population, currency, and languages in a single card. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a city, pass it; otherwise use defaults.',
 
   inputs: {
     city: {
       type: 'string',
-      required: true,
+      required: false,
+      default: 'Tokyo',
       description:
-        'City name (e.g. "Paris", "Tokyo", "Cape Town"). Resolved via geocoding.',
+        'City name (e.g. "Paris", "Tokyo", "Cape Town"). Resolved via geocoding. Has a sensible default — only override if the user specifies a city.',
     },
     units: {
       type: 'string',

--- a/v2/demo-cards/crypto-quote/card.ts
+++ b/v2/demo-cards/crypto-quote/card.ts
@@ -3,13 +3,15 @@ import { defineCard } from '@hashdo/core';
 export default defineCard({
   name: 'do-crypto',
   description:
-    'Look up a cryptocurrency price by coin ID. Shows current price, 24h change, and market cap.',
+    'Look up a cryptocurrency price by coin ID. Shows current price, 24h change, and market cap. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a coin, pass it; otherwise use defaults.',
 
   inputs: {
     coin: {
       type: 'string',
-      required: true,
-      description: 'CoinGecko coin ID (e.g. bitcoin, ethereum, solana)',
+      required: false,
+      default: 'bitcoin',
+      description:
+        'CoinGecko coin ID (e.g. bitcoin, ethereum, solana). Has a sensible default — only override if the user specifies a coin.',
     },
     currency: {
       type: 'string',

--- a/v2/demo-cards/define/card.ts
+++ b/v2/demo-cards/define/card.ts
@@ -10,13 +10,15 @@ import { defineCard } from '@hashdo/core';
 export default defineCard({
   name: 'do-define',
   description:
-    'Look up the definition of any English word. Shows phonetics, meanings, examples, synonyms, and antonyms. Call this when the user types #do/define or asks for a word definition.',
+    'Look up the definition of any English word. Shows phonetics, meanings, examples, synonyms, and antonyms. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a word, pass it; otherwise use defaults.',
 
   inputs: {
     word: {
       type: 'string',
-      required: true,
-      description: 'The English word to define (e.g. "serendipity", "ephemeral")',
+      required: false,
+      default: 'serendipity',
+      description:
+        'The English word to define. Has a sensible default — only override if the user specifies a word.',
     },
   },
 

--- a/v2/demo-cards/github-repo/card.ts
+++ b/v2/demo-cards/github-repo/card.ts
@@ -10,14 +10,15 @@ import { defineCard } from '@hashdo/core';
 export default defineCard({
   name: 'do-repo',
   description:
-    'Look up any public GitHub repository. Shows stars, forks, language, description, topics, and license. Call this when the user types #do/repo or asks about a GitHub repository.',
+    'Look up any public GitHub repository. Shows stars, forks, language, description, topics, and license. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a repo, pass it; otherwise use defaults.',
 
   inputs: {
     repo: {
       type: 'string',
-      required: true,
+      required: false,
+      default: 'facebook/react',
       description:
-        'Repository in "owner/name" format (e.g. "facebook/react", "torvalds/linux") or a GitHub URL',
+        'Repository in "owner/name" format (e.g. "facebook/react", "torvalds/linux") or a GitHub URL. Has a sensible default — only override if the user specifies a repo.',
     },
   },
 

--- a/v2/demo-cards/poll/card.ts
+++ b/v2/demo-cards/poll/card.ts
@@ -51,17 +51,17 @@ export default defineCard({
     return undefined;
   },
 
-  async getData({ inputs, state, baseUrl }) {
-    const inputId = inputs.id as string | undefined;
-    const inputQuestion = inputs.question as string | undefined;
-    const inputOptions = inputs.options as string | undefined;
+  async getData({ inputs, rawInputs, state, baseUrl }) {
+    const inputId = rawInputs.id as string | undefined;
+    const explicitQuestion = rawInputs.question as string | undefined;
+    const explicitOptions = rawInputs.options as string | undefined;
 
     // Determine poll ID — use explicit id, stored id, or derive from question+options
     const pollId =
       inputId ||
       (state.pollId as string) ||
-      (inputQuestion && inputOptions
-        ? derivePollId(inputQuestion, inputOptions)
+      (explicitQuestion && explicitOptions
+        ? derivePollId(explicitQuestion, explicitOptions)
         : undefined);
 
     if (!pollId) {
@@ -70,14 +70,11 @@ export default defineCard({
       );
     }
 
-    // When opening by ID, prefer state (input values may just be schema defaults).
-    // When creating, prefer inputs.
-    const question = inputId
-      ? (state.pollQuestion as string) || inputQuestion || undefined
-      : inputQuestion || (state.pollQuestion as string) || undefined;
-    const optionsRaw = inputId
-      ? (state.pollOptions as string) || inputOptions || undefined
-      : inputOptions || (state.pollOptions as string) || undefined;
+    // Use explicitly provided inputs first, then state, then schema defaults
+    const question =
+      explicitQuestion || (state.pollQuestion as string) || (inputs.question as string);
+    const optionsRaw =
+      explicitOptions || (state.pollOptions as string) || (inputs.options as string);
 
     if (!question || !optionsRaw) {
       if (inputId) {

--- a/v2/demo-cards/qr-code/card.ts
+++ b/v2/demo-cards/qr-code/card.ts
@@ -6,14 +6,17 @@ import { defineCard } from '@hashdo/core';
  */
 export default defineCard({
   name: 'do-qr',
-  description: 'Generate a QR code image from text or a URL. Returns an embeddable QR code.',
+  description:
+    'Generate a QR code image from text or a URL. Returns an embeddable QR code. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions text or a URL, pass it; otherwise use defaults.',
   icon: './icon.svg',
 
   inputs: {
     content: {
       type: 'string',
-      required: true,
-      description: 'The text or URL to encode in the QR code',
+      required: false,
+      default: 'https://hashdo.com',
+      description:
+        'The text or URL to encode in the QR code. Has a sensible default — only override if the user specifies content.',
     },
     size: {
       type: 'number',

--- a/v2/demo-cards/stock-quote/card.ts
+++ b/v2/demo-cards/stock-quote/card.ts
@@ -11,13 +11,15 @@ const marketStateLabels: Record<string, string> = {
 export default defineCard({
   name: 'do-stock',
   description:
-    'Look up a stock price by ticker symbol. Shows current price, daily change, and key stats.',
+    'Look up a stock price by ticker symbol. Shows current price, daily change, and key stats. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a ticker, pass it; otherwise use defaults.',
 
   inputs: {
     symbol: {
       type: 'string',
-      required: true,
-      description: 'Stock ticker symbol (e.g. AAPL, MSFT, TSLA)',
+      required: false,
+      default: 'AAPL',
+      description:
+        'Stock ticker symbol (e.g. AAPL, MSFT, TSLA). Has a sensible default — only override if the user specifies a ticker.',
     },
     currency: {
       type: 'string',

--- a/v2/packages/core/src/define-card.ts
+++ b/v2/packages/core/src/define-card.ts
@@ -1,4 +1,4 @@
-import type { CardDefinition, InputSchema } from './types.js';
+import type { CardDefinition, InputSchema, InputValues } from './types.js';
 
 /**
  * Define a HashDo card.
@@ -6,6 +6,11 @@ import type { CardDefinition, InputSchema } from './types.js';
  * This is the primary API for card authors. It provides type inference
  * so that `getData`, `actions`, and `onWebhook` all have correctly
  * typed input values based on the declared input schema.
+ *
+ * Handles default values: wraps `getData` so that `inputs` contains
+ * resolved values (with defaults applied) while `rawInputs` preserves
+ * the original caller-provided values. Cards can use `rawInputs` to
+ * distinguish explicit input from schema defaults.
  *
  * @example
  * ```ts
@@ -15,8 +20,8 @@ import type { CardDefinition, InputSchema } from './types.js';
  *   inputs: {
  *     city: { type: 'string', required: true, description: 'City name' },
  *   },
- *   async getData({ inputs }) {
- *     // inputs.city is typed as string
+ *   async getData({ inputs, rawInputs }) {
+ *     // inputs.city has defaults applied; rawInputs.city is undefined if not provided
  *     const data = await fetchWeather(inputs.city);
  *     return { viewModel: { temp: data.temp } };
  *   },
@@ -27,5 +32,37 @@ import type { CardDefinition, InputSchema } from './types.js';
 export function defineCard<S extends InputSchema>(
   definition: CardDefinition<S>
 ): CardDefinition<S> {
-  return definition;
+  const originalGetData = definition.getData;
+
+  return {
+    ...definition,
+    getData: async (context) => {
+      // Preserve the original inputs before applying defaults
+      const rawInputs = (context.rawInputs ?? context.inputs) as Partial<InputValues<S>>;
+
+      // Apply schema defaults for any missing inputs
+      const resolvedInputs = { ...context.inputs } as Record<string, unknown>;
+      for (const [key, def] of Object.entries(definition.inputs)) {
+        if (resolvedInputs[key] === undefined && def.default !== undefined) {
+          resolvedInputs[key] = def.default;
+        }
+      }
+
+      // Validate required inputs (after defaults, since a required input could have a default)
+      const missing = Object.entries(definition.inputs)
+        .filter(([key, def]) => def.required && resolvedInputs[key] === undefined)
+        .map(([key]) => key);
+      if (missing.length > 0) {
+        throw new Error(
+          `Missing required input${missing.length > 1 ? 's' : ''} for "${definition.name}": ${missing.join(', ')}`,
+        );
+      }
+
+      return originalGetData({
+        ...context,
+        inputs: resolvedInputs as InputValues<S>,
+        rawInputs,
+      });
+    },
+  };
 }

--- a/v2/packages/core/src/types.ts
+++ b/v2/packages/core/src/types.ts
@@ -83,8 +83,10 @@ export interface ActionResult {
 // ---------------------------------------------------------------------------
 
 export interface GetDataContext<S extends InputSchema = InputSchema> {
-  /** Validated input values */
+  /** Validated input values (with defaults applied for any missing inputs) */
   inputs: InputValues<S>;
+  /** Original input values before defaults were applied. Use this to check whether a value was explicitly provided. */
+  rawInputs: Partial<InputValues<S>>;
   /** Previously persisted card state (empty object on first render) */
   state: CardState;
   /** Base URL of the card server (e.g. "https://app.up.railway.app"). Empty string when unknown. */


### PR DESCRIPTION
## Summary
- **`defineCard` now handles defaults**: wraps `getData` to apply schema defaults and expose `rawInputs` (original caller-provided values), with required-input validation
- **Inline error cards**: `renderCard` catches `getData` errors and renders a styled error card instead of throwing — errors display in the UI with a red gradient header matching card design language
- **All demo cards have defaults**: every card input now has a sensible default (`required: false`), so cards render without parameters — LLMs won't prompt users for inputs
- **Poll card fix**: uses `rawInputs` to correctly prioritize explicit input → state → schema defaults when reopening by ID

## Test plan
- [ ] Visit `http://localhost:3000/card/do-define` with no params — should render "serendipity"
- [ ] Visit `http://localhost:3000/card/do-define?word=llm` — should show styled error card
- [ ] Visit each card URL without params — all should render with defaults
- [ ] Create a poll, then reopen by ID — should preserve original question/options from state

🤖 Generated with [Claude Code](https://claude.com/claude-code)