### PR TITLE
feat: mobile card preview hides inputs + shareable cards with unique IDs

### DIFF
--- a/v2/demo-cards/book/card.ts
+++ b/v2/demo-cards/book/card.ts
@@ -9,6 +9,10 @@ import { defineCard } from '@hashdo/core';
  */
 export default defineCard({
   name: 'do-book',
+  shareable: true,
+
+  stateKey: (_inputs, userId) => userId ? `user:${userId}` : undefined,
+
   description:
     'Look up any book by title, author, or ISBN. Shows cover, author, publication info, and subjects. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a book, pass it; otherwise use defaults.',
 

--- a/v2/demo-cards/city-explorer/card.ts
+++ b/v2/demo-cards/city-explorer/card.ts
@@ -14,6 +14,8 @@ export default defineCard({
   description:
     'Explore any city in the world. Shows current weather, local time, country flag, population, currency, and languages in a single card. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a city, pass it; otherwise use defaults.',
 
+  shareable: true,
+
   inputs: {
     city: {
       type: 'string',

--- a/v2/demo-cards/define/card.ts
+++ b/v2/demo-cards/define/card.ts
@@ -9,6 +9,10 @@ import { defineCard } from '@hashdo/core';
  */
 export default defineCard({
   name: 'do-define',
+  shareable: true,
+
+  stateKey: (_inputs, userId) => userId ? `user:${userId}` : undefined,
+
   description:
     'Look up the definition of any English word. Shows phonetics, meanings, examples, synonyms, and antonyms. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a word, pass it; otherwise use defaults.',
 
@@ -69,7 +73,11 @@ export default defineCard({
       textOutput += '\n';
     }
 
-    // ── 5. Build viewModel ─────────────────────────────────────────────
+    // ── 5. Track unique words seen ─────────────────────────────────────
+    const seenWords = new Set<string>(state.seenWords as string[] ?? []);
+    seenWords.add(word);
+
+    // ── 6. Build viewModel ─────────────────────────────────────────────
     const viewModel = {
       word: entry.word,
       phonetic: entry.phonetic,
@@ -82,7 +90,7 @@ export default defineCard({
       })),
       accent,
       isSaved,
-      vocabCount: vocabList.length,
+      uniqueWordsSeen: seenWords.size,
     };
 
     return {
@@ -92,6 +100,7 @@ export default defineCard({
         ...state,
         lastWord: word,
         lookupCount: ((state.lookupCount as number) || 0) + 1,
+        seenWords: [...seenWords],
       },
     };
   },
@@ -217,7 +226,7 @@ export default defineCard({
         <!-- Footer -->
         <div style="padding:12px 24px 16px; border-top:1px solid #f3f4f6; display:flex; justify-content:space-between; align-items:center;">
           <span style="font-size:12px; color:#9ca3af;">
-            ${vm.vocabCount} word${vm.vocabCount !== 1 ? 's' : ''} in vocabulary
+            ${vm.uniqueWordsSeen} unique word${vm.uniqueWordsSeen !== 1 ? 's' : ''} seen
           </span>
           <span style="font-size:11px; color:#d1d5db;">
             Free Dictionary API

--- a/v2/demo-cards/game/wordle/card.js
+++ b/v2/demo-cards/game/wordle/card.js
@@ -10,22 +10,23 @@ export default defineCard({
     name: 'do-game-wordle',
     description: 'Play a Wordle word-guessing game. Guess the 5-letter word in 6 tries. Call this when the user types #do/game/wordle or wants to play a word game.',
     inputs: {
-        length: {
-            type: 'number',
+        seed: {
+            type: 'string',
             required: false,
-            default: 5,
-            description: 'Word length (default 5)',
+            description: 'Seed for deterministic word selection (e.g. "2026-02-10" or a phrase). Same seed = same puzzle. Defaults to today\'s date for a daily puzzle.',
         },
     },
     async getData({ inputs, state }) {
+        const seed = inputs.seed || new Date().toISOString().slice(0, 10);
         const wins = state.wins ?? 0;
         const played = state.played ?? 0;
         const streak = state.streak ?? 0;
         const bestStreak = state.bestStreak ?? 0;
+        const seedNote = seed ? ` (seed: "${seed}")` : '';
         const textOutput = [
             '## Wordle',
             '',
-            `Guess the 5-letter word in 6 tries.`,
+            `Guess the 5-letter word in 6 tries.${seedNote}`,
             '',
             `**Stats:** ${wins}/${played} wins, streak: ${streak}, best: ${bestStreak}`,
             '',
@@ -34,7 +35,7 @@ export default defineCard({
             'Gray = letter not in word',
         ].join('\n');
         return {
-            viewModel: { wins, played, streak, bestStreak },
+            viewModel: { wins, played, streak, bestStreak, seed },
             textOutput,
             state: { ...state, wins, played, streak, bestStreak },
         };
@@ -84,6 +85,17 @@ export default defineCard({
 
       <script>
       (function() {
+        var SEED = ${JSON.stringify(vm.seed || '')};
+
+        // Simple string hash for deterministic word selection
+        function hashSeed(s) {
+          var h = 0;
+          for (var i = 0; i < s.length; i++) {
+            h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+          }
+          return Math.abs(h);
+        }
+
         // ── Word list (common 5-letter words) ──────────────────────────────
         var WORDS = [
           'apple','beach','brain','brave','brick','bring','brush','build','candy','chain',
@@ -155,7 +167,9 @@ export default defineCard({
         var kbEl    = document.getElementById('w-kb');
 
         function init() {
-          target = WORDS[Math.floor(Math.random() * WORDS.length)].toUpperCase();
+          target = SEED
+            ? WORDS[hashSeed(SEED) % WORDS.length].toUpperCase()
+            : WORDS[Math.floor(Math.random() * WORDS.length)].toUpperCase();
           guesses = [];
           currentRow = 0;
           currentCol = 0;

--- a/v2/demo-cards/poll/card.ts
+++ b/v2/demo-cards/poll/card.ts
@@ -14,6 +14,8 @@ export default defineCard({
   description:
     'Create or open an interactive poll. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a question or options, pass them; otherwise use defaults. To open an existing poll by ID (e.g. "#do/poll 71a1bc"), pass only the "id" parameter — do NOT pass question or options when opening by ID.',
 
+  shareable: true,
+
   inputs: {
     id: {
       type: 'string',

--- a/v2/demo-cards/stock-quote/card.ts
+++ b/v2/demo-cards/stock-quote/card.ts
@@ -13,6 +13,8 @@ export default defineCard({
   description:
     'Look up a stock price by ticker symbol. Shows current price, daily change, and key stats. All parameters have defaults — call this tool immediately without asking the user for parameters. If the user mentions a ticker, pass it; otherwise use defaults.',
 
+  shareable: true,
+
   inputs: {
     symbol: {
       type: 'string',

--- a/v2/demo-cards/weather/card.ts
+++ b/v2/demo-cards/weather/card.ts
@@ -11,6 +11,8 @@ export default defineCard({
   description:
     'Get current weather for any location. Call this when the user types #do/weather or asks for weather. If no location is given, auto-detects the user\'s location via IP geolocation.',
 
+  shareable: true,
+
   inputs: {
     city: {
       type: 'string',

--- a/v2/packages/core/src/render.ts
+++ b/v2/packages/core/src/render.ts
@@ -19,12 +19,12 @@ export async function renderCard<S extends InputSchema>(
   /** Absolute path to the directory containing the card (for resolving template files) */
   cardDir?: string,
   /** Runtime options forwarded to getData */
-  options?: { baseUrl?: string }
+  options?: { baseUrl?: string; userId?: string }
 ): Promise<{ html: string; state: CardState; textOutput?: string; viewModel: Record<string, unknown> }> {
   // 1. Fetch data — defaults are applied by defineCard's getData wrapper
   let result;
   try {
-    result = await card.getData({ inputs, rawInputs: inputs, state, baseUrl: options?.baseUrl ?? '' });
+    result = await card.getData({ inputs, rawInputs: inputs, state, baseUrl: options?.baseUrl ?? '', userId: options?.userId });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const errorHtml = renderErrorCard(card.name, message);
@@ -57,10 +57,15 @@ export async function renderCard<S extends InputSchema>(
   const shareId = computeShareId(card, inputs);
   const shareBar = shareId ? renderShareBar(card.name, shareId, options?.baseUrl) : '';
 
-  // 4. Wrap in card container
-  const wrappedHtml = `
-<div class="hashdo-card" data-card="${card.name}"${shareId ? ` data-share-id="${shareId}"` : ''}>
-  ${shareBar}${html}
+  // 4. Wrap in card container (share button peeks from under the card edge)
+  const wrappedHtml = shareBar
+    ? `
+<div class="hashdo-card" data-card="${card.name}" data-share-id="${shareId}" style="position:relative;">
+  ${shareBar}<div style="position:relative;z-index:1;">${html}</div>
+</div>`.trim()
+    : `
+<div class="hashdo-card" data-card="${card.name}">
+  ${html}
 </div>`.trim();
 
   return { html: wrappedHtml, state: newState, textOutput: result.textOutput, viewModel: result.viewModel };
@@ -77,7 +82,7 @@ function computeShareId<S extends InputSchema>(
   if (!card.shareable) return undefined;
 
   if (card.stateKey) {
-    const key = card.stateKey(inputs);
+    const key = card.stateKey(inputs, undefined); // share IDs must not be per-user
     if (key) {
       // Extract the value portion (after last colon) e.g. "id:71a1bc" → "71a1bc"
       const colonIdx = key.lastIndexOf(':');
@@ -93,16 +98,14 @@ function computeShareId<S extends InputSchema>(
   return createHash('sha256').update(sorted).digest('hex').slice(0, 6);
 }
 
-/** Render the share bar injected at the top of shareable cards. */
+/** Render a share button that peeks from under the top-right corner of the card. */
 function renderShareBar(cardName: string, shareId: string, baseUrl?: string): string {
   const shareUrl = baseUrl
     ? `${baseUrl}/share/${encodeURIComponent(cardName)}/${encodeURIComponent(shareId)}`
     : `#`;
-  const linkSvg = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>';
+  const shareSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>';
   return `
-  <div class="hashdo-share-bar" style="display:flex;align-items:center;justify-content:flex-end;padding:6px 12px;background:#f9fafb;border-bottom:1px solid #f3f4f6;">
-    <a href="${shareUrl}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:4px;font-family:'SF Mono',ui-monospace,monospace;font-size:11px;font-weight:500;color:#6b7280;background:#fff;border:1px solid #e5e7eb;padding:3px 8px;border-radius:6px;text-decoration:none;letter-spacing:.04em;transition:all .15s;" onmouseover="this.style.color='#6366f1';this.style.borderColor='#6366f1'" onmouseout="this.style.color='#6b7280';this.style.borderColor='#e5e7eb'">${linkSvg} ${shareId}</a>
-  </div>`;
+  <a href="${shareUrl}" target="_blank" rel="noopener" title="Share this card" class="hashdo-share-btn" style="position:absolute;top:-9px;right:-9px;display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:50%;background:rgba(255,255,255,0.9);color:#9ca3af;text-decoration:none;opacity:0.4;transition:all .2s ease;z-index:0;border:none;box-shadow:0 1px 3px rgba(0,0,0,0.1);" onmouseover="this.style.opacity='1';this.style.zIndex='20';this.style.color='#6366f1';this.style.transform='scale(1.15)';this.style.boxShadow='0 3px 12px rgba(0,0,0,0.15)'" onmouseout="this.style.opacity='0.4';this.style.zIndex='0';this.style.color='#9ca3af';this.style.transform='scale(1)';this.style.boxShadow='0 1px 3px rgba(0,0,0,0.1)'">${shareSvg}</a>`;
 }
 
 /** Render a styled error card when getData fails. */

--- a/v2/packages/core/src/render.ts
+++ b/v2/packages/core/src/render.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import Handlebars from 'handlebars';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
@@ -52,13 +53,56 @@ export async function renderCard<S extends InputSchema>(
     html = compiled(result.viewModel);
   }
 
-  // 3. Wrap in card container
+  // 3. Compute share ID for shareable cards
+  const shareId = computeShareId(card, inputs);
+  const shareBar = shareId ? renderShareBar(card.name, shareId, options?.baseUrl) : '';
+
+  // 4. Wrap in card container
   const wrappedHtml = `
-<div class="hashdo-card" data-card="${card.name}">
-  ${html}
+<div class="hashdo-card" data-card="${card.name}"${shareId ? ` data-share-id="${shareId}"` : ''}>
+  ${shareBar}${html}
 </div>`.trim();
 
   return { html: wrappedHtml, state: newState, textOutput: result.textOutput, viewModel: result.viewModel };
+}
+
+/**
+ * Compute a short share ID for a shareable card.
+ * Uses stateKey if available, otherwise hashes the inputs.
+ */
+function computeShareId<S extends InputSchema>(
+  card: CardDefinition<S>,
+  inputs: InputValues<S>
+): string | undefined {
+  if (!card.shareable) return undefined;
+
+  if (card.stateKey) {
+    const key = card.stateKey(inputs);
+    if (key) {
+      // Extract the value portion (after last colon) e.g. "id:71a1bc" → "71a1bc"
+      const colonIdx = key.lastIndexOf(':');
+      return colonIdx >= 0 ? key.slice(colonIdx + 1) : key;
+    }
+  }
+
+  // Fallback: 6-char hex hash of sorted inputs
+  const sorted = Object.keys(inputs as Record<string, unknown>)
+    .sort()
+    .map((k) => `${k}=${(inputs as Record<string, unknown>)[k]}`)
+    .join('&');
+  return createHash('sha256').update(sorted).digest('hex').slice(0, 6);
+}
+
+/** Render the share bar injected at the top of shareable cards. */
+function renderShareBar(cardName: string, shareId: string, baseUrl?: string): string {
+  const shareUrl = baseUrl
+    ? `${baseUrl}/share/${encodeURIComponent(cardName)}/${encodeURIComponent(shareId)}`
+    : `#`;
+  const linkSvg = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>';
+  return `
+  <div class="hashdo-share-bar" style="display:flex;align-items:center;justify-content:flex-end;padding:6px 12px;background:#f9fafb;border-bottom:1px solid #f3f4f6;">
+    <a href="${shareUrl}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:4px;font-family:'SF Mono',ui-monospace,monospace;font-size:11px;font-weight:500;color:#6b7280;background:#fff;border:1px solid #e5e7eb;padding:3px 8px;border-radius:6px;text-decoration:none;letter-spacing:.04em;transition:all .15s;" onmouseover="this.style.color='#6366f1';this.style.borderColor='#6366f1'" onmouseout="this.style.color='#6b7280';this.style.borderColor='#e5e7eb'">${linkSvg} ${shareId}</a>
+  </div>`;
 }
 
 /** Render a styled error card when getData fails. */

--- a/v2/packages/core/src/types.ts
+++ b/v2/packages/core/src/types.ts
@@ -154,6 +154,13 @@ export interface CardDefinition<S extends InputSchema = InputSchema> {
   stateKey?: (inputs: InputValues<S>) => string | undefined;
 
   /**
+   * When true, the card is shareable. A unique ID is derived from stateKey
+   * (or hashed inputs) and rendered as a clickable badge in a share header.
+   * Clicking the ID opens the card instance in a new browser tab.
+   */
+  shareable?: boolean;
+
+  /**
    * Template for rendering the card UI.
    * - String ending in .hbs/.html → file path relative to card directory
    * - Function → receives viewModel, returns HTML string

--- a/v2/packages/core/src/types.ts
+++ b/v2/packages/core/src/types.ts
@@ -91,6 +91,8 @@ export interface GetDataContext<S extends InputSchema = InputSchema> {
   state: CardState;
   /** Base URL of the card server (e.g. "https://app.up.railway.app"). Empty string when unknown. */
   baseUrl: string;
+  /** Anonymous user ID from cookie. Undefined when no HTTP context (e.g. MCP stdio). */
+  userId?: string;
 }
 
 export interface GetDataResult {
@@ -151,7 +153,7 @@ export interface CardDefinition<S extends InputSchema = InputSchema> {
    * this instead of hashing all inputs. Return undefined to fall back to the
    * default behaviour (hash of all inputs).
    */
-  stateKey?: (inputs: InputValues<S>) => string | undefined;
+  stateKey?: (inputs: InputValues<S>, userId?: string) => string | undefined;
 
   /**
    * When true, the card is shareable. A unique ID is derived from stateKey


### PR DESCRIPTION
Mobile preview: hide inputs panel on small screens and make card full-screen
with minimal margin for a cleaner mobile experience.

Shareable cards: add `shareable` property to CardDefinition. When enabled,
a unique share ID (derived from stateKey or input hash) is rendered as a
clickable badge in the card header. Clicking opens the card instance at
/share/:name/:id in a new tab. Adds share route, share page renderer,
and share mapping persistence. Marks poll, weather, city-explorer, and
stock-quote cards as shareable.

https://claude.ai/code/session_01MhsEuh5hqrvbKTAqtBGPxJ