### PR TITLE
fix: position share icon relative to card content, not full-width wrapper

### DIFF
--- a/v2/packages/core/src/render.ts
+++ b/v2/packages/core/src/render.ts
@@ -60,7 +60,7 @@ export async function renderCard<S extends InputSchema>(
   // 4. Wrap in card container (share button peeks from under the card edge)
   const wrappedHtml = shareBar
     ? `
-<div class="hashdo-card" data-card="${card.name}" data-share-id="${shareId}" style="position:relative;">
+<div class="hashdo-card" data-card="${card.name}" data-share-id="${shareId}" style="position:relative;width:fit-content;">
   ${shareBar}<div style="position:relative;z-index:1;">${html}</div>
 </div>`.trim()
     : `


### PR DESCRIPTION
The .hashdo-card wrapper stretched to 100% of its parent while inner card
content used max-width (320-420px). The absolutely positioned share button
at right:-9px was offset from the full-width wrapper edge, causing it to
appear far to the right of the visible card on mobile and AI chat views.

Adding width:fit-content shrink-wraps the wrapper to the card content so
the share button stays anchored to the actual card boundary.

https://claude.ai/code/session_016yXq79HktCEAgwFMqephVT