### PR TITLE
feat: add 8px margin around cards for better spacing in AI chat UIs

### DIFF
--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -20,7 +20,7 @@
   color: #000;
   -webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
           box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-  margin: 0;
+  margin: 8px;
   -webkit-border-radius: 2px;
           border-radius: 2px;
   font-size: 14px;

--- a/styles/less/cards.less
+++ b/styles/less/cards.less
@@ -21,7 +21,7 @@
   background: #fff;
   color: #000;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-  margin: 0;
+  margin: 8px;
   border-radius: 2px;
   font-size: 14px;
   width: 225px;

--- a/v2/packages/core/src/render.ts
+++ b/v2/packages/core/src/render.ts
@@ -60,11 +60,11 @@ export async function renderCard<S extends InputSchema>(
   // 4. Wrap in card container (share button peeks from under the card edge)
   const wrappedHtml = shareBar
     ? `
-<div class="hashdo-card" data-card="${card.name}" data-share-id="${shareId}" style="position:relative;width:fit-content;">
+<div class="hashdo-card" data-card="${card.name}" data-share-id="${shareId}" style="position:relative;width:fit-content;margin:8px;">
   ${shareBar}<div style="position:relative;z-index:1;">${html}</div>
 </div>`.trim()
     : `
-<div class="hashdo-card" data-card="${card.name}">
+<div class="hashdo-card" data-card="${card.name}" style="margin:8px;">
   ${html}
 </div>`.trim();
 
@@ -113,7 +113,7 @@ function renderErrorCard(cardName: string, message: string): string {
   const tag = cardName.startsWith('do-') ? `#do/${cardName.slice(3)}` : `#${cardName}`;
   const escaped = message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   return `
-<div class="hashdo-card" data-card="${cardName}">
+<div class="hashdo-card" data-card="${cardName}" style="margin:8px;">
   <div style="font-family:'SF Pro Display',system-ui,-apple-system,sans-serif;max-width:400px;border-radius:20px;overflow:hidden;background:#fff;box-shadow:0 4px 24px rgba(0,0,0,0.08);">
     <div style="padding:24px 24px 20px;background:linear-gradient(135deg,#ef4444,#dc2626);color:#fff;">
       <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">


### PR DESCRIPTION
Cards rendered inside AI chat bubbles (ChatGPT, etc.) had no margin,
causing them to sit flush against the container edges. Adds an 8px
margin to both V1 (.hdc) and V2 (.hashdo-card) card wrappers.

https://claude.ai/code/session_01JKzSxwFyUNo8srbeoycN16