### PR TITLE
fix: persist share mappings from MCP adapter so shared card URLs work

### DIFF
--- a/v2/packages/core/src/render.ts
+++ b/v2/packages/core/src/render.ts
@@ -20,7 +20,7 @@ export async function renderCard<S extends InputSchema>(
   cardDir?: string,
   /** Runtime options forwarded to getData */
   options?: { baseUrl?: string; userId?: string }
-): Promise<{ html: string; state: CardState; textOutput?: string; viewModel: Record<string, unknown> }> {
+): Promise<{ html: string; state: CardState; textOutput?: string; viewModel: Record<string, unknown>; shareId?: string }> {
   // 1. Fetch data — defaults are applied by defineCard's getData wrapper
   let result;
   try {
@@ -68,7 +68,7 @@ export async function renderCard<S extends InputSchema>(
   ${html}
 </div>`.trim();
 
-  return { html: wrappedHtml, state: newState, textOutput: result.textOutput, viewModel: result.viewModel };
+  return { html: wrappedHtml, state: newState, textOutput: result.textOutput, viewModel: result.viewModel, shareId };
 }
 
 /**

--- a/v2/packages/mcp-adapter/src/server.ts
+++ b/v2/packages/mcp-adapter/src/server.ts
@@ -281,6 +281,12 @@ function registerCardTool(
         await stateStore.set(cardKey, result.state);
       }
 
+      // Persist share mapping so /share/:cardName/:shareId can resolve inputs
+      if (card.shareable && result.shareId) {
+        const shareKey = `share:${card.name}:${result.shareId}`;
+        await stateStore.set(shareKey, { _inputs: inputs });
+      }
+
       // Track usage
       const usageKey = `usage:${card.name}`;
       const usageState = await stateStore.get(usageKey);


### PR DESCRIPTION
The MCP adapter was not saving share ID → inputs mappings to the state
store. When cards were rendered via MCP (Claude, ChatGPT, etc.), the
share button URL was generated correctly but the mapping needed to
resolve the share ID back to inputs was never persisted. Visiting a
share URL would fall back to default inputs (e.g. Tokyo for city cards).

- Return shareId from renderCard() so callers can persist share mappings
- Add share mapping persistence to MCP adapter's tool handler
- Remove duplicate computeShareId from cli.ts (now uses renderCard result)

Affects all shareable cards without id/seed inputs: city-explorer,
weather, book, define, stock-quote.

https://claude.ai/code/session_01Q22SKVU6jo5yQD1kHbTLKT