### PR TITLE
feat: unify card architecture around explicit instance ID

### DIFF
--- a/v2/packages/core/src/index.ts
+++ b/v2/packages/core/src/index.ts
@@ -2,6 +2,7 @@
 
 export { defineCard } from './define-card.js';
 export { renderCard } from './render.js';
+export { computeInstanceId, resolveInstance, stableKey, prepareInputs } from './instance.js';
 export { MemoryStateStore } from './state-store.js';
 export { galleryHtml } from './gallery.js';
 export type { GalleryImage, GalleryConfig } from './gallery.js';

--- a/v2/packages/core/src/instance.ts
+++ b/v2/packages/core/src/instance.ts
@@ -1,0 +1,85 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { CardDefinition, InputSchema, InputValues } from './types.js';
+
+/**
+ * For cards with `uniqueInstance: true`, auto-generate an `id` when none was
+ * provided so that every invocation creates a distinct instance.
+ * Call this before `resolveInstance` / `computeInstanceId`.
+ *
+ * Returns inputs unchanged if the card doesn't opt in or already has an `id`.
+ */
+export function prepareInputs<S extends InputSchema>(
+  card: CardDefinition<S>,
+  inputs: Record<string, unknown>,
+): Record<string, unknown> {
+  if (card.uniqueInstance && 'id' in card.inputs && !inputs.id) {
+    return { ...inputs, id: randomBytes(3).toString('hex') };
+  }
+  return inputs;
+}
+
+/**
+ * Create a stable key from input values for state lookups.
+ * Deterministic: same inputs always produce the same key.
+ */
+export function stableKey(obj: Record<string, unknown>): string {
+  const sorted = Object.keys(obj)
+    .sort()
+    .map((k) => `${k}=${obj[k]}`)
+    .join('&');
+  return Buffer.from(sorted).toString('base64url');
+}
+
+/**
+ * Compute the instance ID for a card — a short, URL-safe, user-independent
+ * identifier that uniquely represents this card + inputs combination.
+ *
+ * If the card defines `stateKey()`, extracts the value portion after the last
+ * colon (e.g. `"id:71a1bc"` → `"71a1bc"`). Otherwise falls back to a 6-char
+ * SHA-256 hex hash of sorted inputs.
+ */
+export function computeInstanceId<S extends InputSchema>(
+  card: CardDefinition<S>,
+  inputs: InputValues<S>,
+): string {
+  if (card.stateKey) {
+    // Instance IDs are always user-independent (no userId)
+    const key = card.stateKey(inputs, undefined);
+    if (key) {
+      const colonIdx = key.lastIndexOf(':');
+      return colonIdx >= 0 ? key.slice(colonIdx + 1) : key;
+    }
+  }
+
+  // Fallback: 6-char hex hash of sorted inputs
+  const sorted = Object.keys(inputs as Record<string, unknown>)
+    .sort()
+    .map((k) => `${k}=${(inputs as Record<string, unknown>)[k]}`)
+    .join('&');
+  return createHash('sha256').update(sorted).digest('hex').slice(0, 6);
+}
+
+/**
+ * Resolve the full instance identity for a card render or action.
+ *
+ * Returns:
+ * - `instanceId` — short URL-safe ID (user-independent, suitable for share URLs)
+ * - `cardKey` — full state-store key, may include userId for per-user state cards
+ *
+ * The cardKey format is preserved from the existing convention:
+ * `card:{name}:{stateKey(inputs, userId) || stableKey(inputs)}`
+ */
+export function resolveInstance<S extends InputSchema>(
+  card: CardDefinition<S>,
+  inputs: InputValues<S>,
+  userId?: string,
+): { instanceId: string; cardKey: string } {
+  const instanceId = computeInstanceId(card, inputs);
+
+  const customKey = card.stateKey?.(inputs, userId);
+  const cardKey = customKey
+    ? `card:${card.name}:${customKey}`
+    : `card:${card.name}:${stableKey(inputs as Record<string, unknown>)}`;
+
+  return { instanceId, cardKey };
+}

--- a/v2/packages/core/src/types.ts
+++ b/v2/packages/core/src/types.ts
@@ -163,6 +163,14 @@ export interface CardDefinition<S extends InputSchema = InputSchema> {
   shareable?: boolean;
 
   /**
+   * When true, each invocation without an explicit `id` input creates a new
+   * unique instance (a random ID is auto-generated and injected as `inputs.id`).
+   * Use this for cards like polls where identical inputs should NOT share state.
+   * The card must declare an `id` input in its schema.
+   */
+  uniqueInstance?: boolean;
+
+  /**
    * Template for rendering the card UI.
    * - String ending in .hbs/.html → file path relative to card directory
    * - Function → receives viewModel, returns HTML string


### PR DESCRIPTION
## Summary
- Introduces `instanceId` as a first-class concept in `@hashdo/core` — every card render returns a deterministic, URL-safe identifier
- Centralizes all identity computation in new `core/src/instance.ts`, eliminating 7 ad-hoc `cardKey` construction sites and 4 duplicated functions across CLI and MCP adapter
- Adds `uniqueInstance` flag to `CardDefinition` for cards where each invocation creates a new instance (e.g. polls)
- Fixes bug where cards first rendered via MCP (ChatGPT) had broken share links

## Changes
- **New**: `core/src/instance.ts` — `resolveInstance()`, `computeInstanceId()`, `prepareInputs()`, `stableKey()`
- **New**: `CardDefinition.uniqueInstance` flag + auto-generated `id` injection
- **Modified**: `render.ts` — uses `computeInstanceId`, returns `instanceId`, adds `data-instance-id` to all wrappers
- **Modified**: `mcp-adapter/server.ts` — uses `resolveInstance`, persists instance inputs for share URLs
- **Modified**: `cli/cli.ts` — uses `resolveInstance`, `resolveShareInputs()` with store-first lookup
- **Modified**: `poll/card.ts` — `uniqueInstance: true`, simplified `stateKey`
- **Docs**: Updated README, create-card skill

## Test plan
- [ ] `npm run build` from `v2/` — all packages compile
- [ ] Start dev server, render shareable card — `data-instance-id` in HTML
- [ ] Share URL resolves correctly
- [ ] Create two polls with same question — each gets unique instance
- [ ] Open existing poll by ID — loads correct state

🤖 Generated with [Claude Code](https://claude.com/claude-code)