### PR TITLE
Add CSP resource domains for MCP Apps widget

### DIFF
--- a/v2/packages/cli/src/cli.ts
+++ b/v2/packages/cli/src/cli.ts
@@ -582,6 +582,15 @@ async function cmdStart() {
     enableScreenshots: true,
     stateStore,
     baseUrl: process.env['BASE_URL'] ?? `http://localhost:${port}`,
+    csp: {
+      resourceDomains: [
+        'api.qrserver.com',           // do-qr: QR code images
+        'covers.openlibrary.org',     // do-book: cover images
+        'avatars.githubusercontent.com', // do-github: owner avatars
+        'assets.coingecko.com',       // do-crypto: coin images
+        'upload.wikimedia.org',       // do-city: Wikipedia photos
+      ],
+    },
   };
 
   const server = createServer(async (req, res) => {


### PR DESCRIPTION
## Summary
- Adds `csp` option to `McpCardServerOptions` for declaring widget sandbox domains
- Configures `resourceDomains` for the 5 external image hosts used by demo cards: `api.qrserver.com`, `covers.openlibrary.org`, `avatars.githubusercontent.com`, `assets.coingecko.com`, `upload.wikimedia.org`
- Required for OpenAI app store submission (CSP must allowlist all domains the widget fetches from)

## Test plan
- [ ] Verify build passes (`npm run build` in mcp-adapter and cli)
- [ ] Confirm widget resource includes CSP domains in `_meta.ui.csp.resourceDomains`
- [ ] Test card images load correctly in MCP Apps sandbox (QR codes, book covers, GitHub avatars, crypto icons, city photos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)