### PR TITLE
Add CSP resource domains to stdio serve mode

### DIFF
--- a/v2/packages/cli/src/cli.ts
+++ b/v2/packages/cli/src/cli.ts
@@ -211,6 +211,15 @@ async function cmdServe() {
     cards: discovered.map((d) => d.card),
     cardDirs,
     stateStore,
+    csp: {
+      resourceDomains: [
+        'api.qrserver.com',
+        'covers.openlibrary.org',
+        'avatars.githubusercontent.com',
+        'assets.coingecko.com',
+        'upload.wikimedia.org',
+      ],
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- Adds the same `resourceDomains` CSP config to `cmdServe()` (stdio mode) that was added to `cmdStart()` (HTTP mode) in #39
- Without this, the MCP Inspector (and any stdio-based client) sees empty `resourceDomains` in the widget resource

## Test plan
- [x] Verified via MCP Inspector — widget resource now shows all 5 domains in `resourceDomains`

🤖 Generated with [Claude Code](https://claude.com/claude-code)