### PR TITLE
Add OpenAI domain verification endpoint

### DIFF
--- a/v2/packages/cli/src/cli.ts
+++ b/v2/packages/cli/src/cli.ts
@@ -607,6 +607,14 @@ async function cmdStart() {
     const [userId, needsSetCookie] = resolveUserId(req);
     const cookieHeader = needsSetCookie ? { 'Set-Cookie': makeSetCookie(userId) } : {};
 
+    // OpenAI domain verification
+    if (url.pathname === '/.well-known/openai-apps-challenge' && req.method === 'GET') {
+      const token = process.env['OPENAI_APPS_CHALLENGE_TOKEN'] ?? '';
+      res.writeHead(token ? 200 : 404, { 'Content-Type': 'text/plain' });
+      res.end(token);
+      return;
+    }
+
     // MCP endpoint
     if (url.pathname === '/mcp') {
       // Streamable HTTP only accepts POST (and GET for SSE with sessions).


### PR DESCRIPTION
## Summary
- Adds `GET /.well-known/openai-apps-challenge` route that returns the verification token as plain text
- Token is read from `OPENAI_APPS_CHALLENGE_TOKEN` env var (returns 404 if unset)
- Required for OpenAI app store domain ownership verification

## Setup
Set the env var on Railway with the token from the OpenAI dashboard:
```
OPENAI_APPS_CHALLENGE_TOKEN=<token-from-openai>
```

## Test plan
- [ ] Deploy to Railway with env var set
- [ ] Verify `curl https://hashdo.com/.well-known/openai-apps-challenge` returns the token as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)