### PR TITLE
Fix /mcp endpoint: allow GET/DELETE and add CORS

### DIFF
--- a/v2/packages/cli/src/cli.ts
+++ b/v2/packages/cli/src/cli.ts
@@ -615,21 +615,17 @@ async function cmdStart() {
       return;
     }
 
-    // MCP endpoint
+    // MCP endpoint — let the SDK transport handle POST, GET (SSE), and DELETE
     if (url.pathname === '/mcp') {
-      // Streamable HTTP only accepts POST (and GET for SSE with sessions).
-      // Return a helpful 405 for GET/HEAD so health-checks and URL validators
-      // see the endpoint is alive rather than a confusing 406.
-      if (req.method === 'GET' || req.method === 'HEAD') {
-        res.writeHead(405, {
-          Allow: 'POST',
-          'Content-Type': 'application/json',
+      // CORS preflight for MCP endpoint
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204, {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Accept, Mcp-Session-Id',
+          'Access-Control-Expose-Headers': 'Mcp-Session-Id',
         });
-        res.end(JSON.stringify({
-          jsonrpc: '2.0',
-          error: { code: -32000, message: 'MCP endpoint accepts POST only. Send a JSON-RPC request with Accept: application/json, text/event-stream.' },
-          id: null,
-        }));
+        res.end();
         return;
       }
       try {


### PR DESCRIPTION
## Summary
- Removes the GET/HEAD guard that returned 405 before the SDK transport could handle requests
- The `StreamableHTTPServerTransport` now handles GET (SSE), POST, and DELETE natively
- Adds CORS preflight (OPTIONS) on `/mcp` with `Mcp-Session-Id` exposed
- Required for OpenAI app store — their validator expects GET to reach the transport

## Test plan
- [ ] `POST /mcp` with JSON-RPC still works as before
- [ ] `GET /mcp` returns 405 from the SDK transport (stateless mode) instead of our custom error
- [ ] `OPTIONS /mcp` returns 204 with correct CORS headers
- [ ] OpenAI dashboard can validate the MCP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)