### PR TITLE
fix: use hashed domain for MCP Apps ui.domain

### DIFF
--- a/v2/packages/mcp-adapter/src/server.ts
+++ b/v2/packages/mcp-adapter/src/server.ts
@@ -193,7 +193,7 @@ export function createMcpCardServer(options: McpCardServerOptions) {
         text: WIDGET_HTML,
         _meta: {
           ui: {
-            domain: 'hashdo',
+            domain: '1a92781cb69238237c152ea39363cf28.claudemcpcontent.com',
             csp: {
               connectDomains,
               resourceDomains,


### PR DESCRIPTION
## Summary
- Claude now requires `ui.domain` to be `{sha256-prefix}.claudemcpcontent.com` instead of a plain string
- Updated both occurrences in `mcp-adapter/src/server.ts` from `"hashdo"` to the computed hash
- No impact on ChatGPT — `_meta.ui` is Claude-specific

## Test plan
- [ ] Deploy and verify MCP Apps widgets render in Claude without domain errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)