### PR TITLE
fix: pass resourceDomains to per-tool CSP for image loading

### DIFF
--- a/v2/packages/mcp-adapter/src/server.ts
+++ b/v2/packages/mcp-adapter/src/server.ts
@@ -223,7 +223,7 @@ export function createMcpCardServer(options: McpCardServerOptions) {
   );
 
   for (const card of cards) {
-    registerCardTool(server, card, stateStore, cardDirs[card.name], enableScreenshots, connectDomains, options.baseUrl);
+    registerCardTool(server, card, stateStore, cardDirs[card.name], enableScreenshots, connectDomains, resourceDomains, options.baseUrl);
     registerActionTools(server, card, stateStore);
   }
 
@@ -268,6 +268,7 @@ function registerCardTool(
   cardDir: string | undefined,
   enableScreenshots: boolean,
   connectDomains: string[],
+  resourceDomains: string[],
   baseUrl?: string
 ) {
   const zodShape = inputSchemaToZodShape(card.inputs);
@@ -286,9 +287,9 @@ function registerCardTool(
       _meta: {
         ui: {
           resourceUri: WIDGET_RESOURCE_URI,
-          domain: 'hashdo',
+          domain: '1a92781cb69238237c152ea39363cf28.claudemcpcontent.com',
           csp: {
-            resourceDomains: [],
+            resourceDomains,
             connectDomains,
           },
         },


### PR DESCRIPTION
## Summary
- `registerCardTool` was hardcoding `resourceDomains: []` on each tool's `_meta.ui.csp`, causing Claude's sandbox to block all image loads (e.g. `upload.wikimedia.org` for city-explorer)
- Now passes through the same `resourceDomains` configured at the server level
- Also fixes the remaining stale `domain: 'hashdo'` on the tool-level `_meta.ui`

## Test plan
- [ ] Deploy and verify city-explorer card images load in Claude
- [ ] Verify other cards with images (book covers, QR codes, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)