### PR TITLE
fix: use full origins for CSP resourceDomains

### DIFF
--- a/v2/packages/cli/src/cli.ts
+++ b/v2/packages/cli/src/cli.ts
@@ -213,11 +213,11 @@ async function cmdServe() {
     stateStore,
     csp: {
       resourceDomains: [
-        'api.qrserver.com',
-        'covers.openlibrary.org',
-        'avatars.githubusercontent.com',
-        'assets.coingecko.com',
-        'upload.wikimedia.org',
+        'https://api.qrserver.com',
+        'https://covers.openlibrary.org',
+        'https://avatars.githubusercontent.com',
+        'https://assets.coingecko.com',
+        'https://upload.wikimedia.org',
       ],
     },
   });
@@ -593,11 +593,11 @@ async function cmdStart() {
     baseUrl: process.env['BASE_URL'] ?? `http://localhost:${port}`,
     csp: {
       resourceDomains: [
-        'api.qrserver.com',           // do-qr: QR code images
-        'covers.openlibrary.org',     // do-book: cover images
-        'avatars.githubusercontent.com', // do-github: owner avatars
-        'assets.coingecko.com',       // do-crypto: coin images
-        'upload.wikimedia.org',       // do-city: Wikipedia photos
+        'https://api.qrserver.com',           // do-qr: QR code images
+        'https://covers.openlibrary.org',     // do-book: cover images
+        'https://avatars.githubusercontent.com', // do-github: owner avatars
+        'https://assets.coingecko.com',       // do-crypto: coin images
+        'https://upload.wikimedia.org',       // do-city: Wikipedia photos
       ],
     },
   };


### PR DESCRIPTION
## Summary
- Claude's MCP Apps CSP requires full origins (`https://domain.com`) not bare domains (`domain.com`)
- Bare domains were passed in the iframe URL params but not applied to the actual `img-src` CSP directive
- Updated both stdio and serve mode resource domain lists to include `https://` scheme

## Test plan
- [ ] Deploy and verify city-explorer images load in Claude
- [ ] Verify QR codes, book covers, GitHub avatars, and crypto icons all load

🤖 Generated with [Claude Code](https://claude.com/claude-code)