### PR TITLE
feat: adopt 9-ramp color palette from Anthropic's generative UI design system

### DIFF
--- a/.claude/skills/create-card/SKILL.md
+++ b/.claude/skills/create-card/SKILL.md
@@ -82,7 +82,7 @@ For nested cards, the package name should include the category: `@hashdo/card-<c
 Use this exact structure. Every card follows the same pattern:
 
 ```typescript
-import { defineCard } from '@hashdo/core';
+import { defineCard, colors, gradients, categoricalColors } from '@hashdo/core';
 
 /**
  * #do/<tag> — <Short description>.
@@ -172,8 +172,7 @@ export default defineCard({
   // Template: inline function or .hbs file path
   template: (vm) => `
     <div style="font-family:system-ui,sans-serif; padding:20px; max-width:380px;
-                background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);
-                border-radius:12px; color:white;">
+                background:${gradients.purple}; border-radius:12px; color:white;">
       <!-- Card HTML using viewModel values like ${`\${vm.field}`} -->
     </div>
   `,
@@ -221,9 +220,55 @@ export default defineCard({
 - Use inline `template: (vm) => \`...\`` for self-contained cards
 - Style with inline CSS (no external stylesheets)
 - Target `max-width: 320-400px` for card width
-- Use gradients and `border-radius: 12-20px` for the outer container
+- Use `border-radius: 12-20px` for the outer container
 - Use `system-ui, sans-serif` font stack
 - Design for both light and dark backgrounds
+
+### Color Palette
+Cards **must** use the shared color palette from `@hashdo/core`. Never hardcode ad-hoc hex colors.
+
+```typescript
+import { defineCard, colors, categoricalColors, gradients } from '@hashdo/core';
+```
+
+**9 color ramps** — each with 7 stops (50=lightest → 900=darkest):
+`purple`, `teal`, `coral`, `pink`, `gray`, `blue`, `green`, `amber`, `red`
+
+| Stop | Use |
+|------|-----|
+| 50 | Lightest fill (card backgrounds, badges) |
+| 100-200 | Light fills, hover states |
+| 400 | Mid tone (icons, accents, chart series) |
+| 600 | Strong (borders, strokes, subtitles on light fills) |
+| 800-900 | Text on light fills, darkest shade |
+
+**Usage:**
+```typescript
+colors.purple[50]    // '#EEEDFE' — light purple fill
+colors.purple[400]   // '#7F77DD' — mid purple accent
+colors.purple[800]   // '#3C3489' — text on purple-50 bg
+colors.positive      // green.600 — positive change
+colors.negative      // red.600  — negative change
+```
+
+**Header gradients** — use `gradients.<ramp>` for card headers:
+```typescript
+gradients.purple  // 'linear-gradient(135deg, #7F77DD 0%, #534AB7 100%)'
+gradients.teal    // 'linear-gradient(135deg, #1D9E75 0%, #0F6E56 100%)'
+```
+
+**Categorical coloring** (poll options, chart series) — use `categoricalColors`:
+```typescript
+categoricalColors[i % categoricalColors.length]  // cycles through 9 ramp midpoints
+```
+
+**Rules:**
+- Color encodes **meaning**, not sequence. Group by category, not by order.
+- Use 2-3 ramps per card, not 6+.
+- Prefer `purple`, `teal`, `coral`, `pink` for general categories.
+- Reserve `blue`, `green`, `amber`, `red` for semantic meaning (info, success, warning, error).
+- Text on colored backgrounds: use the 800/900 stop from the **same ramp** as the fill.
+- Positive/negative indicators: `colors.positive` / `colors.negative`.
 
 ### State & Instances
 - `CardState` is `Record<string, unknown>` — arbitrary JSON

--- a/v2/demo-cards/book/card.ts
+++ b/v2/demo-cards/book/card.ts
@@ -1,4 +1,4 @@
-import { defineCard, galleryHtml } from '@hashdo/core';
+import { defineCard, galleryHtml, gradients } from '@hashdo/core';
 import type { GalleryImage } from '@hashdo/core';
 
 /**
@@ -379,33 +379,21 @@ async function searchBooks(query: string, limit: number): Promise<BookResult[]> 
   }
 }
 
-/** Pick an accent color based on the first subject keyword */
+/** Pick an accent gradient based on the first subject keyword */
 function pickAccentColor(subject: string): string {
   const s = subject.toLowerCase();
 
-  if (s.includes('fiction') || s.includes('novel'))
-    return 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)';
-  if (s.includes('science') || s.includes('physics') || s.includes('math'))
-    return 'linear-gradient(135deg, #0ea5e9 0%, #2563eb 100%)';
-  if (s.includes('history') || s.includes('war'))
-    return 'linear-gradient(135deg, #92400e 0%, #b45309 100%)';
-  if (s.includes('fantasy') || s.includes('magic'))
-    return 'linear-gradient(135deg, #7c3aed 0%, #a855f7 100%)';
-  if (s.includes('romance') || s.includes('love'))
-    return 'linear-gradient(135deg, #e11d48 0%, #f43f5e 100%)';
-  if (s.includes('horror') || s.includes('thriller') || s.includes('mystery'))
-    return 'linear-gradient(135deg, #1f2937 0%, #4b5563 100%)';
-  if (s.includes('biography') || s.includes('memoir'))
-    return 'linear-gradient(135deg, #0d9488 0%, #14b8a6 100%)';
-  if (s.includes('children') || s.includes('juvenile'))
-    return 'linear-gradient(135deg, #f59e0b 0%, #f97316 100%)';
-  if (s.includes('philosophy') || s.includes('religion'))
-    return 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)';
-  if (s.includes('art') || s.includes('music') || s.includes('poetry'))
-    return 'linear-gradient(135deg, #ec4899 0%, #f472b6 100%)';
-  if (s.includes('business') || s.includes('economics'))
-    return 'linear-gradient(135deg, #059669 0%, #10b981 100%)';
+  if (s.includes('fiction') || s.includes('novel')) return gradients.purple;
+  if (s.includes('science') || s.includes('physics') || s.includes('math')) return gradients.blue;
+  if (s.includes('history') || s.includes('war')) return gradients.amber;
+  if (s.includes('fantasy') || s.includes('magic')) return gradients.purple;
+  if (s.includes('romance') || s.includes('love')) return gradients.pink;
+  if (s.includes('horror') || s.includes('thriller') || s.includes('mystery')) return gradients.gray;
+  if (s.includes('biography') || s.includes('memoir')) return gradients.teal;
+  if (s.includes('children') || s.includes('juvenile')) return gradients.amber;
+  if (s.includes('philosophy') || s.includes('religion')) return gradients.purple;
+  if (s.includes('art') || s.includes('music') || s.includes('poetry')) return gradients.pink;
+  if (s.includes('business') || s.includes('economics')) return gradients.green;
 
-  // Default warm gradient
-  return 'linear-gradient(135deg, #f97316 0%, #ef4444 100%)';
+  return gradients.coral;
 }

--- a/v2/demo-cards/city-explorer/card.ts
+++ b/v2/demo-cards/city-explorer/card.ts
@@ -1,4 +1,4 @@
-import { defineCard, galleryHtml } from '@hashdo/core';
+import { defineCard, galleryHtml, colors } from '@hashdo/core';
 import type { GalleryImage } from '@hashdo/core';
 
 /**
@@ -616,34 +616,34 @@ function getLocalTime(timezone: string): { formatted: string; hour: number } {
 /** Pick a gradient based on weather and time of day */
 function pickGradient(weatherCode: number, isNight: boolean): string {
   if (isNight) {
-    return 'linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%)';
+    return `linear-gradient(135deg, ${colors.gray[900]} 0%, ${colors.purple[900]} 50%, ${colors.gray[800]} 100%)`;
   }
 
   // Stormy / thunder
   if (weatherCode >= 95) {
-    return 'linear-gradient(135deg, #373B44 0%, #4286f4 100%)';
+    return `linear-gradient(135deg, ${colors.gray[800]} 0%, ${colors.blue[400]} 100%)`;
   }
   // Rain / drizzle
   if (
     (weatherCode >= 51 && weatherCode <= 67) ||
     (weatherCode >= 80 && weatherCode <= 82)
   ) {
-    return 'linear-gradient(135deg, #4B79A1 0%, #283E51 100%)';
+    return `linear-gradient(135deg, ${colors.blue[400]} 0%, ${colors.blue[900]} 100%)`;
   }
   // Snow
   if (weatherCode >= 71 && weatherCode <= 77) {
-    return 'linear-gradient(135deg, #E6DADA 0%, #274046 100%)';
+    return `linear-gradient(135deg, ${colors.gray[100]} 0%, ${colors.teal[900]} 100%)`;
   }
   // Fog
   if (weatherCode >= 45 && weatherCode <= 48) {
-    return 'linear-gradient(135deg, #606c88 0%, #3f4c6b 100%)';
+    return `linear-gradient(135deg, ${colors.gray[400]} 0%, ${colors.gray[800]} 100%)`;
   }
   // Cloudy / overcast
   if (weatherCode >= 2 && weatherCode <= 3) {
-    return 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)';
+    return `linear-gradient(135deg, ${colors.purple[400]} 0%, ${colors.purple[600]} 100%)`;
   }
   // Clear / mainly clear
-  return 'linear-gradient(135deg, #f5af19 0%, #f12711 30%, #e44d26 60%, #c94b4b 100%)';
+  return `linear-gradient(135deg, ${colors.amber[200]} 0%, ${colors.coral[400]} 50%, ${colors.red[400]} 100%)`;
 }
 
 /** Format a number with locale grouping (1,234,567) */

--- a/v2/demo-cards/crypto-quote/card.ts
+++ b/v2/demo-cards/crypto-quote/card.ts
@@ -1,4 +1,4 @@
-import { defineCard } from '@hashdo/core';
+import { defineCard, colors } from '@hashdo/core';
 
 export default defineCard({
   name: 'do-crypto',
@@ -64,7 +64,7 @@ export default defineCard({
     }
 
     const isPositive = data.change24h >= 0;
-    const color = isPositive ? '#22c55e' : '#ef4444';
+    const color = isPositive ? colors.positive : colors.negative;
     const currencyUpper = currency.toUpperCase();
 
     const formatMarketCap = (cap: number): string => {
@@ -130,13 +130,13 @@ export default defineCard({
           ${
             vm.image
               ? `<img src="${vm.image}" alt="${vm.symbol}" style="width:40px; height:40px; border-radius:10px;" />`
-              : `<div style="width:40px; height:40px; border-radius:10px; background:${vm.isPositive ? '#f0fdf4' : '#fef2f2'}; display:flex; align-items:center; justify-content:center; font-size:18px; font-weight:700; color:${vm.color};">${(vm.symbol as string).charAt(0)}</div>`
+              : `<div style="width:40px; height:40px; border-radius:10px; background:${vm.isPositive ? colors.green[50] : colors.red[50]}; display:flex; align-items:center; justify-content:center; font-size:18px; font-weight:700; color:${vm.color};">${(vm.symbol as string).charAt(0)}</div>`
           }
           <div>
             <div style="font-size:16px; font-weight:700; color:#111; letter-spacing:-0.01em;">${vm.symbol}</div>
             <div style="font-size:12px; color:#999; font-weight:400;">${vm.name}</div>
           </div>
-          <div style="margin-left:auto; padding:4px 10px; border-radius:20px; background:${vm.isPositive ? '#f0fdf4' : '#fef2f2'}; color:${vm.color}; font-size:12px; font-weight:600;">${vm.arrow} ${vm.changePercent24h}%</div>
+          <div style="margin-left:auto; padding:4px 10px; border-radius:20px; background:${vm.isPositive ? colors.green[50] : colors.red[50]}; color:${vm.color}; font-size:12px; font-weight:600;">${vm.arrow} ${vm.changePercent24h}%</div>
         </div>
         <div style="margin-bottom:4px;">
           <span style="font-size:36px; font-weight:700; color:#111; letter-spacing:-0.02em;">${typeof vm.price === 'number' ? (vm.price as number).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : vm.price}</span>

--- a/v2/demo-cards/define/card.ts
+++ b/v2/demo-cards/define/card.ts
@@ -1,4 +1,4 @@
-import { defineCard } from '@hashdo/core';
+import { defineCard, colors } from '@hashdo/core';
 
 /**
  * #do/define — Dictionary word lookup card.
@@ -181,11 +181,11 @@ export default defineCard({
       ).join('');
 
       const synRow = m.synonyms.length > 0
-        ? `<div style="margin-top:8px; display:flex; flex-wrap:wrap; gap:4px;">${m.synonyms.map((s: string) => `<span style="padding:2px 8px; border-radius:12px; font-size:11px; background:#f0fdf4; color:#16a34a; border:1px solid #bbf7d0;">${s}</span>`).join('')}</div>`
+        ? `<div style="margin-top:8px; display:flex; flex-wrap:wrap; gap:4px;">${m.synonyms.map((s: string) => `<span style="padding:2px 8px; border-radius:12px; font-size:11px; background:${colors.green[50]}; color:${colors.green[800]}; border:1px solid ${colors.green[100]};">${s}</span>`).join('')}</div>`
         : '';
 
       const antRow = m.antonyms.length > 0
-        ? `<div style="margin-top:6px; display:flex; flex-wrap:wrap; gap:4px;">${m.antonyms.map((a: string) => `<span style="padding:2px 8px; border-radius:12px; font-size:11px; background:#fef2f2; color:#dc2626; border:1px solid #fecaca;">${a}</span>`).join('')}</div>`
+        ? `<div style="margin-top:6px; display:flex; flex-wrap:wrap; gap:4px;">${m.antonyms.map((a: string) => `<span style="padding:2px 8px; border-radius:12px; font-size:11px; background:${colors.red[50]}; color:${colors.red[800]}; border:1px solid ${colors.red[100]};">${a}</span>`).join('')}</div>`
         : '';
 
       return `
@@ -328,14 +328,14 @@ async function lookupWord(word: string): Promise<DictionaryEntry | null> {
 /** Get accent color for a part of speech */
 function posColor(pos: string): string {
   switch (pos.toLowerCase()) {
-    case 'noun': return '#2563eb';
-    case 'verb': return '#dc2626';
-    case 'adjective': return '#7c3aed';
-    case 'adverb': return '#0891b2';
-    case 'pronoun': return '#059669';
-    case 'preposition': return '#d97706';
-    case 'conjunction': return '#be185d';
-    case 'interjection': return '#ea580c';
-    default: return '#6366f1';
+    case 'noun': return colors.blue[600];
+    case 'verb': return colors.red[600];
+    case 'adjective': return colors.purple[600];
+    case 'adverb': return colors.teal[600];
+    case 'pronoun': return colors.green[600];
+    case 'preposition': return colors.amber[600];
+    case 'conjunction': return colors.pink[600];
+    case 'interjection': return colors.coral[600];
+    default: return colors.purple[600];
   }
 }

--- a/v2/demo-cards/github-repo/card.ts
+++ b/v2/demo-cards/github-repo/card.ts
@@ -1,4 +1,4 @@
-import { defineCard } from '@hashdo/core';
+import { defineCard, colors, gradients } from '@hashdo/core';
 
 /**
  * #do/repo — GitHub repository profile card.
@@ -174,7 +174,7 @@ export default defineCard({
 
     const topicPills = topics.length > 0
       ? `<div style="padding:0 24px 16px; display:flex; gap:6px; flex-wrap:wrap;">
-          ${topics.map((t: string) => `<span style="display:inline-block; padding:3px 10px; border-radius:20px; font-size:11px; font-weight:500; background:#f0f4ff; color:#4f46e5; border:1px solid #e0e7ff;">${t}</span>`).join('')}
+          ${topics.map((t: string) => `<span style="display:inline-block; padding:3px 10px; border-radius:20px; font-size:11px; font-weight:500; background:${colors.purple[50]}; color:${colors.purple[800]}; border:1px solid ${colors.purple[100]};">${t}</span>`).join('')}
         </div>`
       : '';
 
@@ -210,17 +210,17 @@ export default defineCard({
 
         <!-- Stats row -->
         <div style="padding:4px 24px 16px; display:flex; gap:10px;">
-          <div style="flex:1; background:#fefce8; border-radius:12px; padding:10px 12px; text-align:center;">
-            <div style="font-size:18px; font-weight:700; color:#ca8a04;">${vm.stars}</div>
-            <div style="font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:#a16207; margin-top:2px;">Stars</div>
+          <div style="flex:1; background:${colors.amber[50]}; border-radius:12px; padding:10px 12px; text-align:center;">
+            <div style="font-size:18px; font-weight:700; color:${colors.amber[800]};">${vm.stars}</div>
+            <div style="font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:${colors.amber[600]}; margin-top:2px;">Stars</div>
           </div>
-          <div style="flex:1; background:#f0fdf4; border-radius:12px; padding:10px 12px; text-align:center;">
-            <div style="font-size:18px; font-weight:700; color:#16a34a;">${vm.forks}</div>
-            <div style="font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:#15803d; margin-top:2px;">Forks</div>
+          <div style="flex:1; background:${colors.green[50]}; border-radius:12px; padding:10px 12px; text-align:center;">
+            <div style="font-size:18px; font-weight:700; color:${colors.green[800]};">${vm.forks}</div>
+            <div style="font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:${colors.green[600]}; margin-top:2px;">Forks</div>
           </div>
-          <div style="flex:1; background:#fef2f2; border-radius:12px; padding:10px 12px; text-align:center;">
-            <div style="font-size:18px; font-weight:700; color:#dc2626;">${vm.openIssues}</div>
-            <div style="font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:#b91c1c; margin-top:2px;">Issues</div>
+          <div style="flex:1; background:${colors.red[50]}; border-radius:12px; padding:10px 12px; text-align:center;">
+            <div style="font-size:18px; font-weight:700; color:${colors.red[800]};">${vm.openIssues}</div>
+            <div style="font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:${colors.red[600]}; margin-top:2px;">Issues</div>
           </div>
         </div>
 
@@ -385,11 +385,12 @@ function timeAgo(iso: string): string {
   }
 }
 
-/** GitHub-style language color */
+/** GitHub-style language color — uses well-known GitHub language colors with palette fallback */
 function languageColor(lang: string | null): string {
-  if (!lang) return 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)';
+  if (!lang) return gradients.purple;
 
-  const colors: Record<string, string> = {
+  // GitHub's canonical language colors (these are widely recognized by developers)
+  const langColors: Record<string, string> = {
     'JavaScript': '#f1e05a',
     'TypeScript': '#3178c6',
     'Python': '#3572A5',
@@ -412,7 +413,7 @@ function languageColor(lang: string | null): string {
     'Svelte': '#ff3e00',
   };
 
-  const solid = colors[lang];
+  const solid = langColors[lang];
   if (solid) return `linear-gradient(135deg, ${solid} 0%, ${solid}dd 100%)`;
-  return 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)';
+  return gradients.purple;
 }

--- a/v2/demo-cards/poll/card.ts
+++ b/v2/demo-cards/poll/card.ts
@@ -1,4 +1,4 @@
-import { defineCard } from '@hashdo/core';
+import { defineCard, categoricalColors, gradients } from '@hashdo/core';
 
 export default defineCard({
   name: 'do-poll',
@@ -93,11 +93,6 @@ export default defineCard({
     const voterCount = (state.voterCount as number) ?? 0;
 
     // Build per-option view data
-    const colors = [
-      '#6366f1', '#f59e0b', '#10b981', '#ef4444',
-      '#8b5cf6', '#ec4899', '#14b8a6', '#f97316',
-    ];
-
     const optionData = optionNames.map((name, i) => {
       const count = votes[name] ?? 0;
       const pct = totalVotes > 0 ? Math.round((count / totalVotes) * 100) : 0;
@@ -105,7 +100,7 @@ export default defineCard({
         name,
         count,
         pct,
-        color: colors[i % colors.length],
+        color: categoricalColors[i % categoricalColors.length],
       };
     });
 
@@ -281,7 +276,7 @@ export default defineCard({
     <div class="poll-card" data-closed="${closed}" data-poll-id="${pollId}" data-api="${vm.apiBaseUrl as string}" data-voter-count="${vm.voterCount as number}">
       <style>
         .poll-card{font-family:'SF Pro Display',system-ui,-apple-system,sans-serif;max-width:400px;background:#fff;border-radius:20px;overflow:hidden;box-shadow:0 4px 24px rgba(0,0,0,.08)}
-        .poll-header{padding:24px 24px 20px;background:linear-gradient(135deg,#6366f1,#8b5cf6);color:#fff}
+        .poll-header{padding:24px 24px 20px;background:${gradients.purple};color:#fff}
         .poll-id{display:inline-block;font-family:'SF Mono',monospace;font-size:11px;font-weight:500;background:rgba(255,255,255,.2);padding:3px 8px;border-radius:6px;letter-spacing:.04em}
         .poll-option{border:2px solid #e5e7eb;border-radius:12px;padding:14px 16px;margin-bottom:10px;cursor:pointer;transition:all .2s;position:relative;overflow:hidden}
         .poll-option:hover{transform:translateX(2px)}

--- a/v2/demo-cards/stock-quote/card.ts
+++ b/v2/demo-cards/stock-quote/card.ts
@@ -1,4 +1,4 @@
-import { defineCard } from '@hashdo/core';
+import { defineCard, colors } from '@hashdo/core';
 
 const marketStateLabels: Record<string, string> = {
   REGULAR: 'Market Open',
@@ -81,7 +81,7 @@ export default defineCard({
         changePercent: changePercent.toFixed(2),
         isPositive: change >= 0,
         arrow: change >= 0 ? '▲' : '▼',
-        color: change >= 0 ? '#22c55e' : '#ef4444',
+        color: change >= 0 ? colors.positive : colors.negative,
         marketLabel: marketStateLabels[quote.marketState as string] ?? 'Market Closed',
         lookupCount: history.length,
       },
@@ -153,12 +153,12 @@ export default defineCard({
     <div style="font-family:'SF Pro Display',system-ui,-apple-system,sans-serif; max-width:340px; background:#fff; border-radius:16px; overflow:hidden;">
       <div style="padding:20px 24px 16px;">
         <div style="display:flex; align-items:center; gap:10px; margin-bottom:16px;">
-          <div style="width:40px; height:40px; border-radius:10px; background:${vm.isPositive ? '#f0fdf4' : '#fef2f2'}; display:flex; align-items:center; justify-content:center; font-size:18px; font-weight:700; color:${vm.color};">${(vm.symbol as string).charAt(0)}</div>
+          <div style="width:40px; height:40px; border-radius:10px; background:${vm.isPositive ? colors.green[50] : colors.red[50]}; display:flex; align-items:center; justify-content:center; font-size:18px; font-weight:700; color:${vm.color};">${(vm.symbol as string).charAt(0)}</div>
           <div>
             <div style="font-size:16px; font-weight:700; color:#111; letter-spacing:-0.01em;">${vm.symbol}</div>
             <div style="font-size:12px; color:#999; font-weight:400;">${vm.name}</div>
           </div>
-          <div style="margin-left:auto; padding:4px 10px; border-radius:20px; background:${vm.isPositive ? '#f0fdf4' : '#fef2f2'}; color:${vm.color}; font-size:12px; font-weight:600;">${vm.arrow} ${vm.changePercent}%</div>
+          <div style="margin-left:auto; padding:4px 10px; border-radius:20px; background:${vm.isPositive ? colors.green[50] : colors.red[50]}; color:${vm.color}; font-size:12px; font-weight:600;">${vm.arrow} ${vm.changePercent}%</div>
         </div>
         <div style="margin-bottom:4px;">
           <span style="font-size:36px; font-weight:700; color:#111; letter-spacing:-0.02em;">${typeof vm.price === 'number' ? (vm.price as number).toFixed(2) : vm.price}</span>

--- a/v2/demo-cards/weather/card.ts
+++ b/v2/demo-cards/weather/card.ts
@@ -1,4 +1,4 @@
-import { defineCard } from '@hashdo/core';
+import { defineCard, gradients } from '@hashdo/core';
 
 /**
  * #do/weather — Current weather conditions.
@@ -197,7 +197,7 @@ export default defineCard({
 
   template: (vm) => `
     <div style="font-family:system-ui,sans-serif; padding:20px; max-width:320px;
-                background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);
+                background:${gradients.purple};
                 border-radius:12px; color:white;">
       <div style="font-size:14px; opacity:0.9; margin-bottom:4px;">
         ${vm.locationName}

--- a/v2/packages/core/src/index.ts
+++ b/v2/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export { computeInstanceId, resolveInstance, stableKey, prepareInputs } from './
 export { MemoryStateStore } from './state-store.js';
 export { galleryHtml } from './gallery.js';
 export type { GalleryImage, GalleryConfig } from './gallery.js';
+export { colors, categoricalColors, rampGradient, gradients } from './palette.js';
+export type { ColorStop, ColorRamp, RampName } from './palette.js';
 
 export type {
   CardDefinition,

--- a/v2/packages/core/src/palette.ts
+++ b/v2/packages/core/src/palette.ts
@@ -1,0 +1,188 @@
+// @hashdo/core — Color palette
+//
+// 9 color ramps, each with 7 stops from lightest (50) to darkest (900).
+// Adapted from Anthropic's generative UI design system.
+//
+// Usage in card templates:
+//   import { colors } from '@hashdo/core';
+//   colors.purple[50]   // '#EEEDFE' (lightest fill)
+//   colors.purple[800]  // '#3C3489' (text on light fills)
+//   colors.positive     // alias for green.600
+//   colors.negative     // alias for red.600
+
+// ---------------------------------------------------------------------------
+// Ramp type
+// ---------------------------------------------------------------------------
+
+export type ColorStop = 50 | 100 | 200 | 400 | 600 | 800 | 900;
+
+export type ColorRamp = Record<ColorStop, string>;
+
+export type RampName =
+  | 'purple'
+  | 'teal'
+  | 'coral'
+  | 'pink'
+  | 'gray'
+  | 'blue'
+  | 'green'
+  | 'amber'
+  | 'red';
+
+// ---------------------------------------------------------------------------
+// Ramps
+// ---------------------------------------------------------------------------
+
+const purple: ColorRamp = {
+  50: '#EEEDFE',
+  100: '#CECBF6',
+  200: '#AFA9EC',
+  400: '#7F77DD',
+  600: '#534AB7',
+  800: '#3C3489',
+  900: '#26215C',
+};
+
+const teal: ColorRamp = {
+  50: '#E1F5EE',
+  100: '#9FE1CB',
+  200: '#5DCAA5',
+  400: '#1D9E75',
+  600: '#0F6E56',
+  800: '#085041',
+  900: '#04342C',
+};
+
+const coral: ColorRamp = {
+  50: '#FAECE7',
+  100: '#F5C4B3',
+  200: '#F0997B',
+  400: '#D85A30',
+  600: '#993C1D',
+  800: '#712B13',
+  900: '#4A1B0C',
+};
+
+const pink: ColorRamp = {
+  50: '#FBEAF0',
+  100: '#F4C0D1',
+  200: '#ED93B1',
+  400: '#D4537E',
+  600: '#993556',
+  800: '#72243E',
+  900: '#4B1528',
+};
+
+const gray: ColorRamp = {
+  50: '#F1EFE8',
+  100: '#D3D1C7',
+  200: '#B4B2A9',
+  400: '#888780',
+  600: '#5F5E5A',
+  800: '#444441',
+  900: '#2C2C2A',
+};
+
+const blue: ColorRamp = {
+  50: '#E6F1FB',
+  100: '#B5D4F4',
+  200: '#85B7EB',
+  400: '#378ADD',
+  600: '#185FA5',
+  800: '#0C447C',
+  900: '#042C53',
+};
+
+const green: ColorRamp = {
+  50: '#EAF3DE',
+  100: '#C0DD97',
+  200: '#97C459',
+  400: '#639922',
+  600: '#3B6D11',
+  800: '#27500A',
+  900: '#173404',
+};
+
+const amber: ColorRamp = {
+  50: '#FAEEDA',
+  100: '#FAC775',
+  200: '#EF9F27',
+  400: '#BA7517',
+  600: '#854F0B',
+  800: '#633806',
+  900: '#412402',
+};
+
+const red: ColorRamp = {
+  50: '#FCEBEB',
+  100: '#F7C1C1',
+  200: '#F09595',
+  400: '#E24B4A',
+  600: '#A32D2D',
+  800: '#791F1F',
+  900: '#501313',
+};
+
+// ---------------------------------------------------------------------------
+// Combined palette
+// ---------------------------------------------------------------------------
+
+export const colors = {
+  purple,
+  teal,
+  coral,
+  pink,
+  gray,
+  blue,
+  green,
+  amber,
+  red,
+
+  // Semantic aliases — use for positive/negative indicators (stock changes, etc.)
+  positive: green[600],
+  negative: red[600],
+  info: blue[600],
+  warning: amber[600],
+  success: green[600],
+  danger: red[600],
+} as const;
+
+// ---------------------------------------------------------------------------
+// Ordered rotation — use for categorical coloring (poll options, chart series)
+// Prefer purple/teal/coral/pink for general categories.
+// Reserve blue/green/amber/red for semantic meaning (info/success/warning/error).
+// ---------------------------------------------------------------------------
+
+export const categoricalColors: readonly string[] = [
+  purple[400],
+  teal[400],
+  coral[400],
+  pink[400],
+  blue[400],
+  green[400],
+  amber[400],
+  red[400],
+  gray[400],
+];
+
+// ---------------------------------------------------------------------------
+// Gradient helpers — for card header backgrounds
+// ---------------------------------------------------------------------------
+
+/** Build a 135deg linear gradient from stop 400 → 600 of a ramp. */
+export function rampGradient(ramp: ColorRamp): string {
+  return `linear-gradient(135deg, ${ramp[400]} 0%, ${ramp[600]} 100%)`;
+}
+
+/** Pre-built gradients keyed by ramp name. */
+export const gradients: Record<RampName, string> = {
+  purple: rampGradient(purple),
+  teal: rampGradient(teal),
+  coral: rampGradient(coral),
+  pink: rampGradient(pink),
+  gray: rampGradient(gray),
+  blue: rampGradient(blue),
+  green: rampGradient(green),
+  amber: rampGradient(amber),
+  red: rampGradient(red),
+};


### PR DESCRIPTION
Add a shared color palette module (`@hashdo/core/palette`) with 9 color
ramps (purple, teal, coral, pink, gray, blue, green, amber, red), each
with 7 stops (50–900). Includes semantic aliases (positive/negative),
categorical color rotation, and pre-built gradient helpers.

Migrate all demo cards from ad-hoc hardcoded hex colors to the shared
palette: weather, stock-quote, crypto-quote, poll, book, city-explorer,
github-repo, and define. Update the create-card skill guide with palette
usage documentation.

https://claude.ai/code/session_011kvoD8NEWw4sbKroucj8XJ